### PR TITLE
feat: add mobile-first tailwind landing

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,162 @@
+<!DOCTYPE html>
+<html lang="ru" class="scroll-smooth">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>SUNCITY Studio</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+</head>
+<body class="bg-white text-gray-800 font-sans">
+  <!-- Sticky header -->
+  <header class="fixed top-0 left-0 w-full bg-white/80 backdrop-blur z-50 border-b">
+    <nav class="max-w-md mx-auto flex justify-between items-center p-4 text-lg">
+      <a href="#hero" class="font-semibold">SUNCITY</a>
+      <div class="space-x-4 text-sm">
+        <a href="#gallery" class="hover:text-orange-500 transition">Фото</a>
+        <a href="#contact" class="hover:text-orange-500 transition">Контакты</a>
+      </div>
+    </nav>
+  </header>
+
+  <!-- Hero -->
+  <section id="hero" class="pt-20 pb-16 text-center max-w-md mx-auto px-4">
+    <h1 class="text-3xl font-bold mb-4">Солнечное пространство для ваших идей</h1>
+    <p class="mb-6">Арендуйте зал для фото, танцев и йоги</p>
+    <a href="#contact" class="inline-block bg-orange-400 text-white px-6 py-3 rounded-full text-lg">Забронировать</a>
+  </section>
+
+  <!-- Advantages -->
+  <section id="advantages" class="max-w-md mx-auto px-4 py-12 space-y-8">
+    <div class="text-center">
+      <h2 class="text-2xl font-semibold mb-4">Почему мы</h2>
+      <ul class="space-y-4">
+        <li class="flex flex-col items-center">
+          <span class="font-medium">Панорамные окна</span>
+          <span class="text-sm text-gray-500">Естественный свет весь день</span>
+        </li>
+        <li class="flex flex-col items-center">
+          <span class="font-medium">Профессиональный зал</span>
+          <span class="text-sm text-gray-500">Зеркала, реквизит и кондиционер</span>
+        </li>
+        <li class="flex flex-col items-center">
+          <span class="font-medium">Простор</span>
+          <span class="text-sm text-gray-500">42м² для групп до 15 человек</span>
+        </li>
+      </ul>
+    </div>
+    <div class="text-center">
+      <a href="#contact" class="inline-block bg-orange-400 text-white px-6 py-3 rounded-full text-lg">Забронировать</a>
+    </div>
+  </section>
+
+  <!-- Services -->
+  <section id="services" class="max-w-md mx-auto px-4 py-12">
+    <h2 class="text-2xl font-semibold text-center mb-8">Услуги</h2>
+    <div class="grid grid-cols-1 gap-6">
+      <div class="p-6 border rounded-xl flex flex-col items-start">
+        <h3 class="font-medium mb-2">Фотосессии</h3>
+        <p class="text-sm text-gray-500 mb-4">Идеальные кадры в светлом зале</p>
+        <a href="#contact" class="mt-auto bg-orange-400 text-white px-4 py-2 rounded-full">Забронировать</a>
+      </div>
+      <div class="p-6 border rounded-xl flex flex-col items-start">
+        <h3 class="font-medium mb-2">Танцы и фитнес</h3>
+        <p class="text-sm text-gray-500 mb-4">Зеркальная стена и музыка</p>
+        <a href="#contact" class="mt-auto bg-orange-400 text-white px-4 py-2 rounded-full">Забронировать</a>
+      </div>
+      <div class="p-6 border rounded-xl flex flex-col items-start">
+        <h3 class="font-medium mb-2">Мастер‑классы</h3>
+        <p class="text-sm text-gray-500 mb-4">Комфорт для групп и встреч</p>
+        <a href="#contact" class="mt-auto bg-orange-400 text-white px-4 py-2 rounded-full">Забронировать</a>
+      </div>
+    </div>
+  </section>
+
+  <!-- Prices -->
+  <section id="pricing" class="max-w-md mx-auto px-4 py-12 bg-gray-50">
+    <h2 class="text-2xl font-semibold text-center mb-8">Цены</h2>
+    <div class="space-y-6">
+      <div class="text-center">
+        <h3 class="font-medium">Фотосъёмки</h3>
+        <p class="text-sm text-gray-500">от 850₽ за 30 минут</p>
+      </div>
+      <div class="text-center">
+        <h3 class="font-medium">Мероприятия</h3>
+        <p class="text-sm text-gray-500">от 500₽ в час</p>
+      </div>
+      <div class="text-center">
+        <a href="#contact" class="inline-block bg-orange-400 text-white px-6 py-3 rounded-full text-lg">Забронировать</a>
+      </div>
+    </div>
+  </section>
+
+  <!-- Gallery -->
+  <section id="gallery" class="max-w-md mx-auto px-4 py-12">
+    <h2 class="text-2xl font-semibold text-center mb-8">Галерея</h2>
+    <div class="grid grid-cols-3 gap-2 mb-6">
+      <img src="https://source.unsplash.com/seed/sun1/200x200" alt="" class="rounded" />
+      <img src="https://source.unsplash.com/seed/sun2/200x200" alt="" class="rounded" />
+      <img src="https://source.unsplash.com/seed/sun3/200x200" alt="" class="rounded" />
+    </div>
+    <div class="text-center">
+      <a href="#gallery" class="inline-block bg-orange-400 text-white px-6 py-3 rounded-full text-lg">Посмотреть фото</a>
+    </div>
+  </section>
+
+  <!-- Reviews -->
+  <section id="reviews" class="max-w-md mx-auto px-4 py-12 bg-gray-50">
+    <h2 class="text-2xl font-semibold text-center mb-8">Отзывы</h2>
+    <div class="space-y-6">
+      <figure class="p-4 border rounded-xl">
+        <blockquote class="text-sm mb-2">«Светлый зал и вид на город — вдохновение!»</blockquote>
+        <figcaption class="text-xs text-gray-500">— Анна</figcaption>
+      </figure>
+      <figure class="p-4 border rounded-xl">
+        <blockquote class="text-sm mb-2">«Идеальное место для наших танцевальных тренингов.»</blockquote>
+        <figcaption class="text-xs text-gray-500">— Игорь</figcaption>
+      </figure>
+      <figure class="p-4 border rounded-xl">
+        <blockquote class="text-sm mb-2">«Бронировали для съёмки, всё прошло гладко.»</blockquote>
+        <figcaption class="text-xs text-gray-500">— Мария</figcaption>
+      </figure>
+    </div>
+    <div class="text-center mt-6">
+      <a href="#contact" class="inline-block bg-orange-400 text-white px-6 py-3 rounded-full text-lg">Забронировать</a>
+    </div>
+  </section>
+
+  <!-- FAQ -->
+  <section id="faq" class="max-w-md mx-auto px-4 py-12">
+    <h2 class="text-2xl font-semibold text-center mb-8">FAQ</h2>
+    <div class="space-y-4">
+      <details class="p-4 border rounded-xl">
+        <summary class="font-medium">Можно перенести бронь?</summary>
+        <p class="mt-2 text-sm text-gray-500">Сообщите нам за 24 часа, и мы перенесём время.</p>
+      </details>
+      <details class="p-4 border rounded-xl">
+        <summary class="font-medium">Есть ли реквизит?</summary>
+        <p class="mt-2 text-sm text-gray-500">Да, кресла, фоны и зеркала включены.</p>
+      </details>
+      <details class="p-4 border rounded-xl">
+        <summary class="font-medium">Как попасть в студию?</summary>
+        <p class="mt-2 text-sm text-gray-500">Вход с торца, лифт на 5 этаж.</p>
+      </details>
+    </div>
+  </section>
+
+  <!-- Contacts -->
+  <section id="contact" class="max-w-md mx-auto px-4 py-12 bg-gray-50">
+    <h2 class="text-2xl font-semibold text-center mb-8">Контакты</h2>
+    <div class="text-center space-y-4">
+      <p>Иркутск, Байкальская 19А</p>
+      <p>+7 902 510‑12‑06</p>
+      <a href="https://yandex.ru/maps" class="text-orange-500 underline">Открыть карту</a>
+    </div>
+    <div class="text-center mt-6">
+      <a href="#contact" class="inline-block bg-orange-400 text-white px-6 py-3 rounded-full text-lg">Забронировать</a>
+    </div>
+  </section>
+
+  <!-- Sticky booking button -->
+  <a href="#contact" class="fixed bottom-4 right-4 bg-orange-500 text-white px-6 py-3 rounded-full shadow-lg text-lg">Забронировать</a>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add responsive Tailwind CSS landing page with hero, benefits, services, pricing, gallery, reviews, FAQ, and contact sections
- include sticky header and floating booking button for quick access on mobile

## Testing
- `npm test` (fails: ENOENT no package.json)


------
https://chatgpt.com/codex/tasks/task_e_688f32d5b3d8832c96490648cb7beabd