### PR TITLE
feat: add booking modal with contact options

### DIFF
--- a/index.html
+++ b/index.html
@@ -66,7 +66,7 @@
       <p class="mb-4">Почасовая аренда для фотосъёмки, йоги, танцев и мероприятий.</p>
       <p class="mb-6 text-sm text-gray-500">Работаем с 2018 года — нас выбрали более 1500 клиентов.</p>
       <div class="flex flex-col sm:flex-row gap-4 justify-center">
-        <a href="#contact" class="bg-orange-500 text-white px-6 py-3 rounded-full text-lg shadow transition">Забронировать</a>
+        <a href="#" class="booking-button bg-orange-500 text-white px-6 py-3 rounded-full text-lg shadow transition">Забронировать</a>
         <a href="#gallery" class="bg-gray-100 text-gray-700 px-6 py-3 rounded-full text-lg shadow transition">Смотреть зал</a>
       </div>
     </div>
@@ -302,7 +302,7 @@
     </div>
     <div class="flex flex-col sm:flex-row gap-4 justify-center mt-6">
       <a href="tel:+79025101206" class="bg-orange-500 text-white px-6 py-3 rounded-full text-lg shadow transition">Связаться</a>
-      <a href="https://t.me/suncity" class="bg-gray-100 text-gray-700 px-6 py-3 rounded-full text-lg shadow transition">Забронировать</a>
+      <a href="#" class="booking-button bg-gray-100 text-gray-700 px-6 py-3 rounded-full text-lg shadow transition">Забронировать</a>
     </div>
   </section>
 
@@ -312,7 +312,29 @@
   </footer>
 
   <!-- Sticky booking button -->
-  <a href="#contact" class="fixed bottom-4 right-4 bg-orange-500 text-white px-6 py-3 rounded-full shadow-lg text-lg transition">Забронировать</a>
+  <a href="#" class="booking-button fixed bottom-4 right-4 bg-orange-500 text-white px-6 py-3 rounded-full shadow-lg text-lg transition">Забронировать</a>
+
+  <!-- Booking modal -->
+  <div id="booking-modal" class="fixed inset-0 z-50 hidden bg-black/60 flex items-end sm:items-center justify-center p-4">
+    <div class="bg-white rounded-3xl w-full max-w-sm overflow-hidden">
+      <div class="p-4 text-center text-gray-500">Выберите способ бронирования</div>
+      <div class="divide-y">
+        <a href="https://wa.me/79025101206" target="_blank" class="flex items-center gap-3 p-4 hover:bg-gray-50">
+          <svg class="w-6 h-6" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" fill="#25D366"><path d="M17.472 14.382c-.297-.149-1.758-.867-2.03-.967-.273-.099-.471-.148-.67.15-.197.297-.767.966-.94 1.164-.173.199-.347.223-.644.075-.297-.15-1.255-.463-2.39-1.475-.883-.788-1.48-1.761-1.653-2.059-.173-.297-.018-.458.13-.606.134-.133.298-.347.446-.52.149-.174.198-.298.298-.497.099-.198.05-.371-.025-.52-.075-.149-.669-1.612-.916-2.207-.242-.579-.487-.5-.669-.51-.173-.008-.371-.01-.57-.01-.198 0-.52.074-.792.372-.272.297-1.04 1.016-1.04 2.479 0 1.462 1.065 2.875 1.213 3.074.149.198 2.096 3.2 5.077 4.487.709.306 1.262.489 1.694.625.712.227 1.36.195 1.871.118.571-.085 1.758-.719 2.006-1.413.248-.694.248-1.289.173-1.413-.074-.124-.272-.198-.57-.347m-5.421 7.403h-.004a9.87 9.87 0 01-5.031-1.378l-.361-.214-3.741.982.998-3.648-.235-.374a9.86 9.86 0 01-1.51-5.26c.001-5.45 4.436-9.884 9.888-9.884 2.64 0 5.122 1.03 6.988 2.898a9.825 9.825 0 012.893 6.994c-.003 5.45-4.437 9.884-9.885 9.884m8.413-18.297A11.815 11.815 0 0012.05 0C5.495 0 .16 5.335.157 11.892c0 2.096.547 4.142 1.588 5.945L.057 24l6.305-1.654a11.882 11.882 0 005.683 1.448h.005c6.554 0 11.89-5.335 11.893-11.893a11.821 11.821 0 00-3.48-8.413Z"/></svg>
+          <span>WhatsApp: +7&nbsp;902&nbsp;510‑12‑06</span>
+        </a>
+        <a href="https://t.me/yousee_this" target="_blank" class="flex items-center gap-3 p-4 hover:bg-gray-50">
+          <svg class="w-6 h-6" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" fill="#0088cc"><path d="M11.944 0A12 12 0 0 0 0 12a12 12 0 0 0 12 12 12 12 0 0 0 12-12A12 12 0 0 0 12 0a12 12 0 0 0-.056 0zm4.962 7.224c.1-.002.321.023.465.14a.506.506 0 0 1 .17.325c.016.093.036.306.02.472-.18 1.898-.962 6.502-1.36 8.627-.168.9-.499 1.201-.82 1.23-.696.065-1.225-.46-1.9-.902-1.056-.693-1.653-1.124-2.678-1.8-1.185-.78-.417-1.21.258-1.91.177-.184 3.247-2.977 3.307-3.23.007-.032.014-.15-.056-.212s-.174-.041-.249-.024c-.106.024-1.793 1.14-5.061 3.345-.48.33-.913.49-1.302.48-.428-.008-1.252-.241-1.865-.44-.752-.245-1.349-.374-1.297-.789.027-.216.325-.437.893-.663 3.498-1.524 5.83-2.529 6.998-3.014 3.332-1.386 4.025-1.627 4.476-1.635z"/></svg>
+          <span>Telegram: @yousee_this</span>
+        </a>
+        <a href="https://dikidi.ru/1321360" target="_blank" class="flex items-center gap-3 p-4 hover:bg-gray-50">
+          <svg class="w-6 h-6" viewBox="0 0 24 24" fill="none" stroke="#f97316" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" xmlns="http://www.w3.org/2000/svg"><path d="M8 2v4"/><path d="M16 2v4"/><rect width="18" height="18" x="3" y="4" rx="2"/><path d="M3 10h18"/></svg>
+          <span>Онлайн через Dikidi</span>
+        </a>
+      </div>
+      <button id="close-booking" class="w-full p-4 text-center text-red-500">Отмена</button>
+    </div>
+  </div>
 
   <script src="https://cdn.jsdelivr.net/npm/swiper@9/swiper-bundle.min.js"></script>
   <script>
@@ -321,6 +343,18 @@
       loop: true,
       pagination: { el: '.swiper-pagination', clickable: true },
       navigation: { nextEl: '.swiper-button-next', prevEl: '.swiper-button-prev' },
+    });
+    const bookingModal = document.getElementById('booking-modal');
+    const closeBooking = () => bookingModal.classList.add('hidden');
+    document.querySelectorAll('.booking-button').forEach(btn => {
+      btn.addEventListener('click', e => {
+        e.preventDefault();
+        bookingModal.classList.remove('hidden');
+      });
+    });
+    document.getElementById('close-booking').addEventListener('click', closeBooking);
+    bookingModal.addEventListener('click', e => {
+      if (e.target === bookingModal) closeBooking();
     });
   </script>
 


### PR DESCRIPTION
## Summary
- add iOS-style booking modal with WhatsApp, Telegram and Dikidi links
- wire all "Забронировать" buttons to open the modal

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689395d89610832cb2284d53d05e6fb3