### PR TITLE
Add services, pricing, and booking links to navigation

### DIFF
--- a/index.html
+++ b/index.html
@@ -50,8 +50,11 @@
     <nav class="max-w-screen-md mx-auto flex justify-between items-center p-4 text-lg">
       <a href="#hero" class="font-semibold">SUNCITY</a>
       <div class="space-x-4 text-sm">
+        <a href="#services" class="hover:text-orange-500 transition">Услуги</a>
+        <a href="#pricing" class="hover:text-orange-500 transition">Цены</a>
         <a href="#gallery" class="hover:text-orange-500 transition">Смотреть зал</a>
         <a href="#contact" class="hover:text-orange-500 transition">Связаться с нами</a>
+        <a href="#" class="booking-button hover:text-orange-500 transition">Забронировать</a>
       </div>
     </nav>
   </header>


### PR DESCRIPTION
## Summary
- add Services and Prices sections to top menu
- add menu booking link that opens the booking modal

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689398fdf89c832caafc246170e11a9e