### PR TITLE
Use vertical placeholder images

### DIFF
--- a/index.html
+++ b/index.html
@@ -60,7 +60,7 @@
   </header>
 
   <!-- Hero -->
-  <section id="hero" class="relative pt-24 pb-20 text-center max-w-screen-md mx-auto px-4 overflow-hidden bg-center bg-cover" style="background-image:url('https://images.unsplash.com/photo-1504384308090-c894fdcc538d?auto=format&fit=crop&w=1600&q=80');">
+  <section id="hero" class="relative pt-24 pb-20 text-center max-w-screen-md mx-auto px-4 overflow-hidden bg-center bg-cover" style="background-image:url('https://images.unsplash.com/photo-1504384308090-c894fdcc538d?auto=format&fit=crop&w=800&h=1200&q=80');">
     <div class="absolute inset-0 bg-white/70"></div>
     <div class="absolute top-0 left-0 right-0 h-24 bg-white"></div>
     <div class="relative z-10">
@@ -119,9 +119,9 @@
     <div class="grid grid-cols-1 sm:grid-cols-2 gap-6">
       <div class="p-6 border rounded-xl shadow flex flex-col">
         <div class="mb-4 grid grid-cols-3 gap-2">
-          <img src="https://source.unsplash.com/seed/photo1/200x150" alt="Фотосъёмка" data-service="photo" class="w-full h-24 object-cover rounded cursor-pointer service-image" />
-          <img src="https://source.unsplash.com/seed/photo2/200x150" alt="Фотосъёмка" data-service="photo" class="w-full h-24 object-cover rounded cursor-pointer service-image" />
-          <img src="https://source.unsplash.com/seed/photo3/200x150" alt="Фотосъёмка" data-service="photo" class="w-full h-24 object-cover rounded cursor-pointer service-image" />
+          <img src="https://source.unsplash.com/seed/photo1/150x200" alt="Фотосъёмка" data-service="photo" class="w-full h-24 object-cover rounded cursor-pointer service-image" />
+          <img src="https://source.unsplash.com/seed/photo2/150x200" alt="Фотосъёмка" data-service="photo" class="w-full h-24 object-cover rounded cursor-pointer service-image" />
+          <img src="https://source.unsplash.com/seed/photo3/150x200" alt="Фотосъёмка" data-service="photo" class="w-full h-24 object-cover rounded cursor-pointer service-image" />
         </div>
         <h3 class="text-xl font-semibold mb-2">Фотосъёмка</h3>
         <p class="text-sm text-gray-500 mb-4">Профессиональные кадры в светлом зале</p>
@@ -129,9 +129,9 @@
       </div>
       <div class="p-6 border rounded-xl shadow flex flex-col">
         <div class="mb-4 grid grid-cols-3 gap-2">
-          <img src="https://source.unsplash.com/seed/yoga1/200x150" alt="Йога" data-service="yoga" class="w-full h-24 object-cover rounded cursor-pointer service-image" />
-          <img src="https://source.unsplash.com/seed/yoga2/200x150" alt="Йога" data-service="yoga" class="w-full h-24 object-cover rounded cursor-pointer service-image" />
-          <img src="https://source.unsplash.com/seed/yoga3/200x150" alt="Йога" data-service="yoga" class="w-full h-24 object-cover rounded cursor-pointer service-image" />
+          <img src="https://source.unsplash.com/seed/yoga1/150x200" alt="Йога" data-service="yoga" class="w-full h-24 object-cover rounded cursor-pointer service-image" />
+          <img src="https://source.unsplash.com/seed/yoga2/150x200" alt="Йога" data-service="yoga" class="w-full h-24 object-cover rounded cursor-pointer service-image" />
+          <img src="https://source.unsplash.com/seed/yoga3/150x200" alt="Йога" data-service="yoga" class="w-full h-24 object-cover rounded cursor-pointer service-image" />
         </div>
         <h3 class="text-xl font-semibold mb-2">Йога</h3>
         <p class="text-sm text-gray-500 mb-4">Спокойное пространство для практик</p>
@@ -139,9 +139,9 @@
       </div>
       <div class="p-6 border rounded-xl shadow flex flex-col">
         <div class="mb-4 grid grid-cols-3 gap-2">
-          <img src="https://source.unsplash.com/seed/dance1/200x150" alt="Танцы" data-service="dance" class="w-full h-24 object-cover rounded cursor-pointer service-image" />
-          <img src="https://source.unsplash.com/seed/dance2/200x150" alt="Танцы" data-service="dance" class="w-full h-24 object-cover rounded cursor-pointer service-image" />
-          <img src="https://source.unsplash.com/seed/dance3/200x150" alt="Танцы" data-service="dance" class="w-full h-24 object-cover rounded cursor-pointer service-image" />
+          <img src="https://source.unsplash.com/seed/dance1/150x200" alt="Танцы" data-service="dance" class="w-full h-24 object-cover rounded cursor-pointer service-image" />
+          <img src="https://source.unsplash.com/seed/dance2/150x200" alt="Танцы" data-service="dance" class="w-full h-24 object-cover rounded cursor-pointer service-image" />
+          <img src="https://source.unsplash.com/seed/dance3/150x200" alt="Танцы" data-service="dance" class="w-full h-24 object-cover rounded cursor-pointer service-image" />
         </div>
         <h3 class="text-xl font-semibold mb-2">Танцы</h3>
         <p class="text-sm text-gray-500 mb-4">Удобный зал для тренировок</p>
@@ -149,9 +149,9 @@
       </div>
       <div class="p-6 border rounded-xl shadow flex flex-col">
         <div class="mb-4 grid grid-cols-3 gap-2">
-          <img src="https://source.unsplash.com/seed/event1/200x150" alt="Мероприятия" data-service="event" class="w-full h-24 object-cover rounded cursor-pointer service-image" />
-          <img src="https://source.unsplash.com/seed/event2/200x150" alt="Мероприятия" data-service="event" class="w-full h-24 object-cover rounded cursor-pointer service-image" />
-          <img src="https://source.unsplash.com/seed/event3/200x150" alt="Мероприятия" data-service="event" class="w-full h-24 object-cover rounded cursor-pointer service-image" />
+          <img src="https://source.unsplash.com/seed/event1/150x200" alt="Мероприятия" data-service="event" class="w-full h-24 object-cover rounded cursor-pointer service-image" />
+          <img src="https://source.unsplash.com/seed/event2/150x200" alt="Мероприятия" data-service="event" class="w-full h-24 object-cover rounded cursor-pointer service-image" />
+          <img src="https://source.unsplash.com/seed/event3/150x200" alt="Мероприятия" data-service="event" class="w-full h-24 object-cover rounded cursor-pointer service-image" />
         </div>
         <h3 class="text-xl font-semibold mb-2">Мероприятия</h3>
         <p class="text-sm text-gray-500 mb-4">Проведение мастер-классов и встреч</p>
@@ -194,33 +194,33 @@
 
   <!-- Gallery -->
   <section id="gallery" class="relative py-12">
-    <div class="absolute inset-0 bg-[url('https://images.unsplash.com/photo-1600585154340-be6161a56a0c?auto=format&fit=crop&w=1600&q=80')] bg-cover bg-center blur-sm"></div>
+    <div class="absolute inset-0 bg-[url('https://images.unsplash.com/photo-1600585154340-be6161a56a0c?auto=format&fit=crop&w=800&h=1200&q=80')] bg-cover bg-center blur-sm"></div>
     <div class="relative max-w-screen-md mx-auto px-4">
       <h2 class="text-2xl font-semibold text-center mb-8 text-white">Галерея</h2>
       <div class="swiper">
         <div class="swiper-wrapper">
           <div class="swiper-slide relative">
-            <img src="https://source.unsplash.com/seed/sun1/800x600" alt="Светлый зал" class="w-full h-64 object-cover rounded" />
+            <img src="https://source.unsplash.com/seed/sun1/600x800" alt="Светлый зал" class="w-full h-64 object-cover rounded" />
             <div class="absolute bottom-0 left-0 w-full bg-black/50 text-white text-xs text-center py-1">Светлый зал</div>
           </div>
           <div class="swiper-slide relative">
-            <img src="https://source.unsplash.com/seed/sun2/800x600" alt="Панорамные окна" class="w-full h-64 object-cover rounded" />
+            <img src="https://source.unsplash.com/seed/sun2/600x800" alt="Панорамные окна" class="w-full h-64 object-cover rounded" />
             <div class="absolute bottom-0 left-0 w-full bg-black/50 text-white text-xs text-center py-1">Панорамные окна</div>
           </div>
           <div class="swiper-slide relative">
-            <img src="https://source.unsplash.com/seed/sun3/800x600" alt="Реквизит" class="w-full h-64 object-cover rounded" />
+            <img src="https://source.unsplash.com/seed/sun3/600x800" alt="Реквизит" class="w-full h-64 object-cover rounded" />
             <div class="absolute bottom-0 left-0 w-full bg-black/50 text-white text-xs text-center py-1">Реквизит</div>
           </div>
           <div class="swiper-slide relative">
-            <img src="https://source.unsplash.com/seed/sun4/800x600" alt="Йога" class="w-full h-64 object-cover rounded" />
+            <img src="https://source.unsplash.com/seed/sun4/600x800" alt="Йога" class="w-full h-64 object-cover rounded" />
             <div class="absolute bottom-0 left-0 w-full bg-black/50 text-white text-xs text-center py-1">Йога</div>
           </div>
           <div class="swiper-slide relative">
-            <img src="https://source.unsplash.com/seed/sun5/800x600" alt="Танцы" class="w-full h-64 object-cover rounded" />
+            <img src="https://source.unsplash.com/seed/sun5/600x800" alt="Танцы" class="w-full h-64 object-cover rounded" />
             <div class="absolute bottom-0 left-0 w-full bg-black/50 text-white text-xs text-center py-1">Танцы</div>
           </div>
           <div class="swiper-slide relative">
-            <img src="https://source.unsplash.com/seed/sun6/800x600" alt="Мероприятия" class="w-full h-64 object-cover rounded" />
+            <img src="https://source.unsplash.com/seed/sun6/600x800" alt="Мероприятия" class="w-full h-64 object-cover rounded" />
             <div class="absolute bottom-0 left-0 w-full bg-black/50 text-white text-xs text-center py-1">Мероприятия</div>
           </div>
         </div>
@@ -352,7 +352,7 @@
   </section>
 
   <footer class="bg-white py-8 text-center text-sm text-gray-500">
-    <img src="https://source.unsplash.com/seed/building/300x150" alt="Вход в студию" class="mx-auto mb-4 w-48 h-32 object-cover rounded" />
+    <img src="https://source.unsplash.com/seed/building/150x300" alt="Вход в студию" class="mx-auto mb-4 w-32 h-48 object-cover rounded" />
     <p>© 2018–2025 SUNCITY</p>
   </footer>
 
@@ -417,24 +417,24 @@
 
       const serviceGalleries = {
         photo: [
-          'https://source.unsplash.com/seed/photo1/800x600',
-          'https://source.unsplash.com/seed/photo2/800x600',
-          'https://source.unsplash.com/seed/photo3/800x600',
+          'https://source.unsplash.com/seed/photo1/600x800',
+          'https://source.unsplash.com/seed/photo2/600x800',
+          'https://source.unsplash.com/seed/photo3/600x800',
         ],
         yoga: [
-          'https://source.unsplash.com/seed/yoga1/800x600',
-          'https://source.unsplash.com/seed/yoga2/800x600',
-          'https://source.unsplash.com/seed/yoga3/800x600',
+          'https://source.unsplash.com/seed/yoga1/600x800',
+          'https://source.unsplash.com/seed/yoga2/600x800',
+          'https://source.unsplash.com/seed/yoga3/600x800',
         ],
         dance: [
-          'https://source.unsplash.com/seed/dance1/800x600',
-          'https://source.unsplash.com/seed/dance2/800x600',
-          'https://source.unsplash.com/seed/dance3/800x600',
+          'https://source.unsplash.com/seed/dance1/600x800',
+          'https://source.unsplash.com/seed/dance2/600x800',
+          'https://source.unsplash.com/seed/dance3/600x800',
         ],
         event: [
-          'https://source.unsplash.com/seed/event1/800x600',
-          'https://source.unsplash.com/seed/event2/800x600',
-          'https://source.unsplash.com/seed/event3/800x600',
+          'https://source.unsplash.com/seed/event1/600x800',
+          'https://source.unsplash.com/seed/event2/600x800',
+          'https://source.unsplash.com/seed/event3/600x800',
         ],
       };
 


### PR DESCRIPTION
## Summary
- update hero and gallery backgrounds to vertical crops
- replace service thumbnails and gallery items with vertical Unsplash links
- adjust footer photo and modal galleries to use vertical placeholders

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6894db83ef84832c95c4b3ebfe8ccc19