### PR TITLE
Enable themed galleries across site

### DIFF
--- a/arenda-zala-irkutsk/index.html
+++ b/arenda-zala-irkutsk/index.html
@@ -13,6 +13,7 @@
 <meta name="twitter:description" content="Зеркала, естественный свет и реквизит в центре Иркутска" />
 <meta name="twitter:image" content="https://suncitystudio.ru/img/og-image.jpg" />
 <script src="https://cdn.tailwindcss.com"></script>
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/swiper@9/swiper-bundle.min.css" />
 <script src="https://unpkg.com/lucide@latest"></script>
 <script type="application/ld+json">
 {
@@ -84,9 +85,9 @@
 <p class="mb-4">Выберите свободный слот в нашем календаре и подтвердите бронь онлайн. Оплата доступна наличными, по переводу или по счёту для юрлиц. Если планы изменились, перенести время можно без штрафа за 24 часа до начала аренды. По запросу мы предоставим дополнительный реквизит: коврики для йоги, стулья, проектор или чайную зону.</p>
 <h2 class="text-2xl font-semibold mb-2">Галерея</h2>
 <div class="grid grid-cols-3 gap-2 mb-6">
-  <img src="https://images.unsplash.com/photo-1521737604893-d14cc237f11d?auto=format&fit=crop&w=400&q=80" alt="Зал SUNCITY — аренда в Иркутске" loading="lazy" class="w-full h-40 object-cover rounded" />
-  <img src="https://images.unsplash.com/photo-1526285849418-9b93f0b6b497?auto=format&fit=crop&w=400&q=80" alt="Зеркальный зал SUNCITY Иркутск" loading="lazy" class="w-full h-40 object-cover rounded" />
-  <img src="https://images.unsplash.com/photo-1529778873920-4da4926a72c2?auto=format&fit=crop&w=400&q=80" alt="Аренда зала SUNCITY Иркутск" loading="lazy" class="w-full h-40 object-cover rounded" />
+  <img src="../img/f1.webp" alt="Зал SUNCITY — фотосъёмка" loading="lazy" data-service="all" class="w-full aspect-[4/5] object-cover rounded cursor-pointer service-image" />
+  <img src="../img/m1.webp" alt="Зал SUNCITY — мероприятие" loading="lazy" data-service="all" class="w-full aspect-[4/5] object-cover rounded cursor-pointer service-image" />
+  <img src="../img/i1.webp" alt="Зал SUNCITY — йога" loading="lazy" data-service="all" class="w-full aspect-[4/5] object-cover rounded cursor-pointer service-image" />
 </div>
 <div class="mb-8 text-center">
   <a href="https://dikidi.ru/1321360?utm_source=site&utm_medium=button&utm_campaign=booking" target="_blank" rel="nofollow" class="inline-block bg-orange-500 text-white px-6 py-3 rounded-full">Забронировать</a>
@@ -135,6 +136,19 @@
 }
 </script>
 </main>
+
+  <!-- Service gallery modal -->
+  <div id="service-modal" class="fixed inset-0 z-50 hidden bg-black/80 flex items-center justify-center p-4">
+    <div class="relative inline-block max-w-[90vw] max-h-[90vh]">
+      <div class="swiper service-swiper">
+        <div class="swiper-wrapper" id="service-swiper-wrapper"></div>
+        <div class="swiper-pagination service-pagination"></div>
+        <div class="swiper-button-prev service-prev text-white"></div>
+        <div class="swiper-button-next service-next text-white"></div>
+      </div>
+      <button id="close-service-modal" class="absolute top-2 right-2 text-white">✕</button>
+    </div>
+  </div>
 <footer class="mt-12 border-t pt-4 text-center text-sm text-gray-500">
   <p>&copy; 2024 SUNCITY, Иркутск</p>
   <nav class="mt-2 flex justify-center space-x-4">
@@ -142,10 +156,51 @@
     <a href="/suncitystudio.ru/kontakty/" class="hover:text-orange-500">Контакты</a>
   </nav>
 </footer>
+<script src="https://cdn.jsdelivr.net/npm/swiper@9/swiper-bundle.min.js"></script>
 <script>
-const menuToggle=document.getElementById('menu-toggle');
-const mobileMenu=document.getElementById('mobile-menu');
-menuToggle.addEventListener('click',()=>mobileMenu.classList.toggle('hidden'));
+const menuToggle = document.getElementById('menu-toggle');
+const mobileMenu = document.getElementById('mobile-menu');
+menuToggle.addEventListener('click', () => mobileMenu.classList.toggle('hidden'));
+
+const base = '../img/';
+const serviceGalleries = {
+  photo: Array.from({ length: 34 }, (_, i) => `${base}f${i + 1}.webp`),
+  yoga: Array.from({ length: 3 }, (_, i) => `${base}i${i + 1}.webp`),
+  dance: Array.from({ length: 4 }, (_, i) => `${base}t${i + 1}.webp`),
+  event: Array.from({ length: 5 }, (_, i) => `${base}m${i + 1}.webp`),
+};
+serviceGalleries.all = [...serviceGalleries.photo, ...serviceGalleries.yoga, ...serviceGalleries.dance, ...serviceGalleries.event];
+
+const serviceModal = document.getElementById('service-modal');
+const serviceWrapper = document.getElementById('service-swiper-wrapper');
+let serviceSwiper;
+
+document.querySelectorAll('.service-image').forEach(img => {
+  img.addEventListener('click', () => {
+    const key = img.dataset.service;
+    serviceWrapper.innerHTML = '';
+    serviceGalleries[key].forEach(url => {
+      const slide = document.createElement('div');
+      slide.className = 'swiper-slide flex items-center justify-center';
+      slide.innerHTML = `<img src="${url}" loading="lazy" class="max-h-[90vh] max-w-[90vw] w-auto h-auto object-contain rounded" />`;
+      serviceWrapper.appendChild(slide);
+    });
+    if (serviceSwiper) serviceSwiper.destroy(true, true);
+    serviceSwiper = new Swiper('.service-swiper', {
+      loop: true,
+      autoHeight: true,
+      pagination: { el: '.service-pagination', clickable: true },
+      navigation: { nextEl: '.service-next', prevEl: '.service-prev' },
+    });
+    serviceModal.classList.remove('hidden');
+  });
+});
+
+const closeService = () => serviceModal.classList.add('hidden');
+document.getElementById('close-service-modal').addEventListener('click', closeService);
+serviceModal.addEventListener('click', e => {
+  if (!e.target.closest('img') && !e.target.closest('.service-prev') && !e.target.closest('.service-next') && !e.target.closest('.service-pagination')) closeService();
+});
 </script>
 </body>
 </html>

--- a/fly-yoga-irkutsk/index.html
+++ b/fly-yoga-irkutsk/index.html
@@ -13,6 +13,7 @@
 <meta name="twitter:description" content="Аренда зала с гамаками для аэро-йоги" />
 <meta name="twitter:image" content="https://suncitystudio.ru/img/og-image.jpg" />
 <script src="https://cdn.tailwindcss.com"></script>
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/swiper@9/swiper-bundle.min.css" />
 <script src="https://unpkg.com/lucide@latest"></script>
 <script type="application/ld+json">
 {
@@ -80,9 +81,9 @@
 <p class="mb-4">Студия находится в центре города, рядом с остановками. В наличии душ и зона для переодевания. Благодаря акустике и белым стенам можно проводить и фотосессии в гамаках. Почасовая аренда даёт свободу планировать занятия в удобное время.</p>
 <h2 class="text-2xl font-semibold mb-2">Галерея</h2>
 <div class="grid grid-cols-3 gap-2 mb-6">
-  <img src="https://images.unsplash.com/photo-1518611012118-f73c9be83749?auto=format&fit=crop&w=400&q=80" alt="Флай-йога гамак Иркутск" loading="lazy" class="w-full h-40 object-cover rounded" />
-  <img src="https://images.unsplash.com/photo-1540202404-1bdd79aeb5d3?auto=format&fit=crop&w=400&q=80" alt="Зал для аэро-йоги SUNCITY" loading="lazy" class="w-full h-40 object-cover rounded" />
-  <img src="https://images.unsplash.com/photo-1503676260728-1c00da094a0b?auto=format&fit=crop&w=400&q=80" alt="Аренда зала с гамаками Иркутск" loading="lazy" class="w-full h-40 object-cover rounded" />
+  <img src="../img/i1.webp" alt="Флай-йога гамак Иркутск" loading="lazy" data-service="yoga" class="w-full aspect-[4/5] object-cover rounded cursor-pointer service-image" />
+  <img src="../img/i2.webp" alt="Зал для аэро-йоги SUNCITY" loading="lazy" data-service="yoga" class="w-full aspect-[4/5] object-cover rounded cursor-pointer service-image" />
+  <img src="../img/i3.webp" alt="Аренда зала с гамаками Иркутск" loading="lazy" data-service="yoga" class="w-full aspect-[4/5] object-cover rounded cursor-pointer service-image" />
 </div>
 <div class="mb-8 text-center">
   <a href="https://dikidi.ru/1321360?utm_source=site&utm_medium=button&utm_campaign=booking" target="_blank" rel="nofollow" class="inline-block bg-orange-500 text-white px-6 py-3 rounded-full">Забронировать</a>
@@ -131,6 +132,19 @@
 }
 </script>
 </main>
+
+  <!-- Service gallery modal -->
+  <div id="service-modal" class="fixed inset-0 z-50 hidden bg-black/80 flex items-center justify-center p-4">
+    <div class="relative inline-block max-w-[90vw] max-h-[90vh]">
+      <div class="swiper service-swiper">
+        <div class="swiper-wrapper" id="service-swiper-wrapper"></div>
+        <div class="swiper-pagination service-pagination"></div>
+        <div class="swiper-button-prev service-prev text-white"></div>
+        <div class="swiper-button-next service-next text-white"></div>
+      </div>
+      <button id="close-service-modal" class="absolute top-2 right-2 text-white">✕</button>
+    </div>
+  </div>
 <footer class="mt-12 border-t pt-4 text-center text-sm text-gray-500">
   <p>&copy; 2024 SUNCITY, Иркутск</p>
   <nav class="mt-2 flex justify-center space-x-4">
@@ -138,10 +152,51 @@
     <a href="/suncitystudio.ru/kontakty/" class="hover:text-orange-500">Контакты</a>
   </nav>
 </footer>
+<script src="https://cdn.jsdelivr.net/npm/swiper@9/swiper-bundle.min.js"></script>
 <script>
-const menuToggle=document.getElementById('menu-toggle');
-const mobileMenu=document.getElementById('mobile-menu');
-menuToggle.addEventListener('click',()=>mobileMenu.classList.toggle('hidden'));
+const menuToggle = document.getElementById('menu-toggle');
+const mobileMenu = document.getElementById('mobile-menu');
+menuToggle.addEventListener('click', () => mobileMenu.classList.toggle('hidden'));
+
+const base = '../img/';
+const serviceGalleries = {
+  photo: Array.from({ length: 34 }, (_, i) => `${base}f${i + 1}.webp`),
+  yoga: Array.from({ length: 3 }, (_, i) => `${base}i${i + 1}.webp`),
+  dance: Array.from({ length: 4 }, (_, i) => `${base}t${i + 1}.webp`),
+  event: Array.from({ length: 5 }, (_, i) => `${base}m${i + 1}.webp`),
+};
+serviceGalleries.all = [...serviceGalleries.photo, ...serviceGalleries.yoga, ...serviceGalleries.dance, ...serviceGalleries.event];
+
+const serviceModal = document.getElementById('service-modal');
+const serviceWrapper = document.getElementById('service-swiper-wrapper');
+let serviceSwiper;
+
+document.querySelectorAll('.service-image').forEach(img => {
+  img.addEventListener('click', () => {
+    const key = img.dataset.service;
+    serviceWrapper.innerHTML = '';
+    serviceGalleries[key].forEach(url => {
+      const slide = document.createElement('div');
+      slide.className = 'swiper-slide flex items-center justify-center';
+      slide.innerHTML = `<img src="${url}" loading="lazy" class="max-h-[90vh] max-w-[90vw] w-auto h-auto object-contain rounded" />`;
+      serviceWrapper.appendChild(slide);
+    });
+    if (serviceSwiper) serviceSwiper.destroy(true, true);
+    serviceSwiper = new Swiper('.service-swiper', {
+      loop: true,
+      autoHeight: true,
+      pagination: { el: '.service-pagination', clickable: true },
+      navigation: { nextEl: '.service-next', prevEl: '.service-prev' },
+    });
+    serviceModal.classList.remove('hidden');
+  });
+});
+
+const closeService = () => serviceModal.classList.add('hidden');
+document.getElementById('close-service-modal').addEventListener('click', closeService);
+serviceModal.addEventListener('click', e => {
+  if (!e.target.closest('img') && !e.target.closest('.service-prev') && !e.target.closest('.service-next') && !e.target.closest('.service-pagination')) closeService();
+});
 </script>
 </body>
 </html>

--- a/fotostudiya-irkutsk/index.html
+++ b/fotostudiya-irkutsk/index.html
@@ -13,6 +13,7 @@
 <meta name="twitter:description" content="Почасовая аренда с естественным светом" />
 <meta name="twitter:image" content="https://suncitystudio.ru/img/og-image.jpg" />
 <script src="https://cdn.tailwindcss.com"></script>
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/swiper@9/swiper-bundle.min.css" />
 <script src="https://unpkg.com/lucide@latest"></script>
 <script type="application/ld+json">
 {
@@ -82,9 +83,9 @@
 <p class="mb-4">Вы можете выбрать свободное время в онлайн‑календаре или связаться с нами в мессенджерах. Оплата принимается наличными, переводом или по счёту. Для постоянных клиентов доступны скидки и возможность хранения реквизита в студии.</p>
 <h2 class="text-2xl font-semibold mb-2">Галерея</h2>
 <div class="grid grid-cols-3 gap-2 mb-6">
-  <img src="../img/f1.webp" alt="Фотостудия SUNCITY Иркутск" loading="lazy" class="w-full h-40 object-cover rounded" />
-  <img src="../img/f2.webp" alt="Естественный свет фотостудии SUNCITY" loading="lazy" class="w-full h-40 object-cover rounded" />
-  <img src="../img/f3.webp" alt="Реквизит фотостудии SUNCITY Иркутск" loading="lazy" class="w-full h-40 object-cover rounded" />
+  <img src="../img/f1.webp" alt="Фотостудия SUNCITY Иркутск" loading="lazy" data-service="photo" class="w-full aspect-[4/5] object-cover rounded cursor-pointer service-image" />
+  <img src="../img/f2.webp" alt="Естественный свет фотостудии SUNCITY" loading="lazy" data-service="photo" class="w-full aspect-[4/5] object-cover rounded cursor-pointer service-image" />
+  <img src="../img/f3.webp" alt="Реквизит фотостудии SUNCITY Иркутск" loading="lazy" data-service="photo" class="w-full aspect-[4/5] object-cover rounded cursor-pointer service-image" />
 </div>
 <div class="mb-8 text-center">
   <a href="https://dikidi.ru/1321360?utm_source=site&utm_medium=button&utm_campaign=booking" target="_blank" rel="nofollow" class="inline-block bg-orange-500 text-white px-6 py-3 rounded-full">Забронировать</a>
@@ -133,6 +134,19 @@
 }
 </script>
 </main>
+
+  <!-- Service gallery modal -->
+  <div id="service-modal" class="fixed inset-0 z-50 hidden bg-black/80 flex items-center justify-center p-4">
+    <div class="relative inline-block max-w-[90vw] max-h-[90vh]">
+      <div class="swiper service-swiper">
+        <div class="swiper-wrapper" id="service-swiper-wrapper"></div>
+        <div class="swiper-pagination service-pagination"></div>
+        <div class="swiper-button-prev service-prev text-white"></div>
+        <div class="swiper-button-next service-next text-white"></div>
+      </div>
+      <button id="close-service-modal" class="absolute top-2 right-2 text-white">✕</button>
+    </div>
+  </div>
 <footer class="mt-12 border-t pt-4 text-center text-sm text-gray-500">
   <p>&copy; 2024 SUNCITY, Иркутск</p>
   <nav class="mt-2 flex justify-center space-x-4">
@@ -140,10 +154,51 @@
     <a href="/suncitystudio.ru/kontakty/" class="hover:text-orange-500">Контакты</a>
   </nav>
 </footer>
+<script src="https://cdn.jsdelivr.net/npm/swiper@9/swiper-bundle.min.js"></script>
 <script>
-const menuToggle=document.getElementById('menu-toggle');
-const mobileMenu=document.getElementById('mobile-menu');
-menuToggle.addEventListener('click',()=>mobileMenu.classList.toggle('hidden'));
+const menuToggle = document.getElementById('menu-toggle');
+const mobileMenu = document.getElementById('mobile-menu');
+menuToggle.addEventListener('click', () => mobileMenu.classList.toggle('hidden'));
+
+const base = '../img/';
+const serviceGalleries = {
+  photo: Array.from({ length: 34 }, (_, i) => `${base}f${i + 1}.webp`),
+  yoga: Array.from({ length: 3 }, (_, i) => `${base}i${i + 1}.webp`),
+  dance: Array.from({ length: 4 }, (_, i) => `${base}t${i + 1}.webp`),
+  event: Array.from({ length: 5 }, (_, i) => `${base}m${i + 1}.webp`),
+};
+serviceGalleries.all = [...serviceGalleries.photo, ...serviceGalleries.yoga, ...serviceGalleries.dance, ...serviceGalleries.event];
+
+const serviceModal = document.getElementById('service-modal');
+const serviceWrapper = document.getElementById('service-swiper-wrapper');
+let serviceSwiper;
+
+document.querySelectorAll('.service-image').forEach(img => {
+  img.addEventListener('click', () => {
+    const key = img.dataset.service;
+    serviceWrapper.innerHTML = '';
+    serviceGalleries[key].forEach(url => {
+      const slide = document.createElement('div');
+      slide.className = 'swiper-slide flex items-center justify-center';
+      slide.innerHTML = `<img src="${url}" loading="lazy" class="max-h-[90vh] max-w-[90vw] w-auto h-auto object-contain rounded" />`;
+      serviceWrapper.appendChild(slide);
+    });
+    if (serviceSwiper) serviceSwiper.destroy(true, true);
+    serviceSwiper = new Swiper('.service-swiper', {
+      loop: true,
+      autoHeight: true,
+      pagination: { el: '.service-pagination', clickable: true },
+      navigation: { nextEl: '.service-next', prevEl: '.service-prev' },
+    });
+    serviceModal.classList.remove('hidden');
+  });
+});
+
+const closeService = () => serviceModal.classList.add('hidden');
+document.getElementById('close-service-modal').addEventListener('click', closeService);
+serviceModal.addEventListener('click', e => {
+  if (!e.target.closest('img') && !e.target.closest('.service-prev') && !e.target.closest('.service-next') && !e.target.closest('.service-pagination')) closeService();
+});
 </script>
 </body>
 </html>

--- a/gender-party-irkutsk/index.html
+++ b/gender-party-irkutsk/index.html
@@ -13,6 +13,7 @@
 <meta name="twitter:description" content="Gender reveal в стильной студии" />
 <meta name="twitter:image" content="https://suncitystudio.ru/img/og-image.jpg" />
 <script src="https://cdn.tailwindcss.com"></script>
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/swiper@9/swiper-bundle.min.css" />
 <script src="https://unpkg.com/lucide@latest"></script>
 <script type="application/ld+json">
 {
@@ -80,9 +81,9 @@
 <p class="mb-4">Центральное расположение облегчает приезд гостей, а парковка делает встречу беззаботной. Кнопка «Забронировать» позволяет заранее выбрать удобное время. Зал подходит и для других праздников: выпускных из роддома, дней рождений и семейных фотосессий.</p>
 <h2 class="text-2xl font-semibold mb-2">Галерея</h2>
 <div class="grid grid-cols-3 gap-2 mb-6">
-  <img src="https://images.unsplash.com/photo-1511732351157-1865efcb7c76?auto=format&fit=crop&w=400&q=80" alt="Гендер-пати зал SUNCITY Иркутск" loading="lazy" class="w-full h-40 object-cover rounded" />
-  <img src="https://images.unsplash.com/photo-1529626455594-4ff0802cfb7e?auto=format&fit=crop&w=400&q=80" alt="Оформление гендер-пати SUNCITY" loading="lazy" class="w-full h-40 object-cover rounded" />
-  <img src="https://images.unsplash.com/photo-1607082350916-9b19a6440b82?auto=format&fit=crop&w=400&q=80" alt="Gender reveal Иркутск" loading="lazy" class="w-full h-40 object-cover rounded" />
+  <img src="../img/m1.webp" alt="Гендер-пати зал SUNCITY Иркутск" loading="lazy" data-service="event" class="w-full aspect-[4/5] object-cover rounded cursor-pointer service-image" />
+  <img src="../img/m2.webp" alt="Оформление гендер-пати SUNCITY" loading="lazy" data-service="event" class="w-full aspect-[4/5] object-cover rounded cursor-pointer service-image" />
+  <img src="../img/m3.webp" alt="Gender reveal Иркутск" loading="lazy" data-service="event" class="w-full aspect-[4/5] object-cover rounded cursor-pointer service-image" />
 </div>
 <div class="mb-8 text-center">
   <a href="https://dikidi.ru/1321360?utm_source=site&utm_medium=button&utm_campaign=booking" target="_blank" rel="nofollow" class="inline-block bg-orange-500 text-white px-6 py-3 rounded-full">Забронировать</a>
@@ -131,6 +132,19 @@
 }
 </script>
 </main>
+
+  <!-- Service gallery modal -->
+  <div id="service-modal" class="fixed inset-0 z-50 hidden bg-black/80 flex items-center justify-center p-4">
+    <div class="relative inline-block max-w-[90vw] max-h-[90vh]">
+      <div class="swiper service-swiper">
+        <div class="swiper-wrapper" id="service-swiper-wrapper"></div>
+        <div class="swiper-pagination service-pagination"></div>
+        <div class="swiper-button-prev service-prev text-white"></div>
+        <div class="swiper-button-next service-next text-white"></div>
+      </div>
+      <button id="close-service-modal" class="absolute top-2 right-2 text-white">✕</button>
+    </div>
+  </div>
 <footer class="mt-12 border-t pt-4 text-center text-sm text-gray-500">
   <p>&copy; 2024 SUNCITY, Иркутск</p>
   <nav class="mt-2 flex justify-center space-x-4">
@@ -138,10 +152,51 @@
     <a href="/suncitystudio.ru/kontakty/" class="hover:text-orange-500">Контакты</a>
   </nav>
 </footer>
+<script src="https://cdn.jsdelivr.net/npm/swiper@9/swiper-bundle.min.js"></script>
 <script>
-const menuToggle=document.getElementById('menu-toggle');
-const mobileMenu=document.getElementById('mobile-menu');
-menuToggle.addEventListener('click',()=>mobileMenu.classList.toggle('hidden'));
+const menuToggle = document.getElementById('menu-toggle');
+const mobileMenu = document.getElementById('mobile-menu');
+menuToggle.addEventListener('click', () => mobileMenu.classList.toggle('hidden'));
+
+const base = '../img/';
+const serviceGalleries = {
+  photo: Array.from({ length: 34 }, (_, i) => `${base}f${i + 1}.webp`),
+  yoga: Array.from({ length: 3 }, (_, i) => `${base}i${i + 1}.webp`),
+  dance: Array.from({ length: 4 }, (_, i) => `${base}t${i + 1}.webp`),
+  event: Array.from({ length: 5 }, (_, i) => `${base}m${i + 1}.webp`),
+};
+serviceGalleries.all = [...serviceGalleries.photo, ...serviceGalleries.yoga, ...serviceGalleries.dance, ...serviceGalleries.event];
+
+const serviceModal = document.getElementById('service-modal');
+const serviceWrapper = document.getElementById('service-swiper-wrapper');
+let serviceSwiper;
+
+document.querySelectorAll('.service-image').forEach(img => {
+  img.addEventListener('click', () => {
+    const key = img.dataset.service;
+    serviceWrapper.innerHTML = '';
+    serviceGalleries[key].forEach(url => {
+      const slide = document.createElement('div');
+      slide.className = 'swiper-slide flex items-center justify-center';
+      slide.innerHTML = `<img src="${url}" loading="lazy" class="max-h-[90vh] max-w-[90vw] w-auto h-auto object-contain rounded" />`;
+      serviceWrapper.appendChild(slide);
+    });
+    if (serviceSwiper) serviceSwiper.destroy(true, true);
+    serviceSwiper = new Swiper('.service-swiper', {
+      loop: true,
+      autoHeight: true,
+      pagination: { el: '.service-pagination', clickable: true },
+      navigation: { nextEl: '.service-next', prevEl: '.service-prev' },
+    });
+    serviceModal.classList.remove('hidden');
+  });
+});
+
+const closeService = () => serviceModal.classList.add('hidden');
+document.getElementById('close-service-modal').addEventListener('click', closeService);
+serviceModal.addEventListener('click', e => {
+  if (!e.target.closest('img') && !e.target.closest('.service-prev') && !e.target.closest('.service-next') && !e.target.closest('.service-pagination')) closeService();
+});
 </script>
 </body>
 </html>

--- a/meropriyatiya-irkutsk/index.html
+++ b/meropriyatiya-irkutsk/index.html
@@ -13,6 +13,7 @@
 <meta name="twitter:description" content="Аренда зала для встреч и мастер-классов" />
 <meta name="twitter:image" content="https://suncitystudio.ru/img/og-image.jpg" />
 <script src="https://cdn.tailwindcss.com"></script>
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/swiper@9/swiper-bundle.min.css" />
 <script src="https://unpkg.com/lucide@latest"></script>
 <script type="application/ld+json">
 {
@@ -80,9 +81,9 @@
 <p class="mb-4">Наше пространство выбирают организаторы тренингов, психологических групп, творческих встреч и праздников. Расположение в центре Иркутска удобно для гостей, а наличие парковки решает вопрос с автомобилями.</p>
 <h2 class="text-2xl font-semibold mb-2">Галерея</h2>
 <div class="grid grid-cols-3 gap-2 mb-6">
-  <img src="../img/m1.webp" alt="Зал для мероприятий SUNCITY Иркутск" loading="lazy" class="w-full h-40 object-cover rounded" />
-  <img src="../img/m2.webp" alt="Мастер-класс в SUNCITY Иркутск" loading="lazy" class="w-full h-40 object-cover rounded" />
-  <img src="../img/m3.webp" alt="Аренда зала для встречи Иркутск" loading="lazy" class="w-full h-40 object-cover rounded" />
+  <img src="../img/m1.webp" alt="Зал для мероприятий SUNCITY Иркутск" loading="lazy" data-service="event" class="w-full aspect-[4/5] object-cover rounded cursor-pointer service-image" />
+  <img src="../img/m2.webp" alt="Мастер-класс в SUNCITY Иркутск" loading="lazy" data-service="event" class="w-full aspect-[4/5] object-cover rounded cursor-pointer service-image" />
+  <img src="../img/m3.webp" alt="Аренда зала для встречи Иркутск" loading="lazy" data-service="event" class="w-full aspect-[4/5] object-cover rounded cursor-pointer service-image" />
 </div>
 <div class="mb-8 text-center">
   <a href="https://dikidi.ru/1321360?utm_source=site&utm_medium=button&utm_campaign=booking" target="_blank" rel="nofollow" class="inline-block bg-orange-500 text-white px-6 py-3 rounded-full">Забронировать</a>
@@ -131,6 +132,19 @@
 }
 </script>
 </main>
+
+  <!-- Service gallery modal -->
+  <div id="service-modal" class="fixed inset-0 z-50 hidden bg-black/80 flex items-center justify-center p-4">
+    <div class="relative inline-block max-w-[90vw] max-h-[90vh]">
+      <div class="swiper service-swiper">
+        <div class="swiper-wrapper" id="service-swiper-wrapper"></div>
+        <div class="swiper-pagination service-pagination"></div>
+        <div class="swiper-button-prev service-prev text-white"></div>
+        <div class="swiper-button-next service-next text-white"></div>
+      </div>
+      <button id="close-service-modal" class="absolute top-2 right-2 text-white">✕</button>
+    </div>
+  </div>
 <footer class="mt-12 border-t pt-4 text-center text-sm text-gray-500">
   <p>&copy; 2024 SUNCITY, Иркутск</p>
   <nav class="mt-2 flex justify-center space-x-4">
@@ -138,10 +152,51 @@
     <a href="/suncitystudio.ru/kontakty/" class="hover:text-orange-500">Контакты</a>
   </nav>
 </footer>
+<script src="https://cdn.jsdelivr.net/npm/swiper@9/swiper-bundle.min.js"></script>
 <script>
-const menuToggle=document.getElementById('menu-toggle');
-const mobileMenu=document.getElementById('mobile-menu');
-menuToggle.addEventListener('click',()=>mobileMenu.classList.toggle('hidden'));
+const menuToggle = document.getElementById('menu-toggle');
+const mobileMenu = document.getElementById('mobile-menu');
+menuToggle.addEventListener('click', () => mobileMenu.classList.toggle('hidden'));
+
+const base = '../img/';
+const serviceGalleries = {
+  photo: Array.from({ length: 34 }, (_, i) => `${base}f${i + 1}.webp`),
+  yoga: Array.from({ length: 3 }, (_, i) => `${base}i${i + 1}.webp`),
+  dance: Array.from({ length: 4 }, (_, i) => `${base}t${i + 1}.webp`),
+  event: Array.from({ length: 5 }, (_, i) => `${base}m${i + 1}.webp`),
+};
+serviceGalleries.all = [...serviceGalleries.photo, ...serviceGalleries.yoga, ...serviceGalleries.dance, ...serviceGalleries.event];
+
+const serviceModal = document.getElementById('service-modal');
+const serviceWrapper = document.getElementById('service-swiper-wrapper');
+let serviceSwiper;
+
+document.querySelectorAll('.service-image').forEach(img => {
+  img.addEventListener('click', () => {
+    const key = img.dataset.service;
+    serviceWrapper.innerHTML = '';
+    serviceGalleries[key].forEach(url => {
+      const slide = document.createElement('div');
+      slide.className = 'swiper-slide flex items-center justify-center';
+      slide.innerHTML = `<img src="${url}" loading="lazy" class="max-h-[90vh] max-w-[90vw] w-auto h-auto object-contain rounded" />`;
+      serviceWrapper.appendChild(slide);
+    });
+    if (serviceSwiper) serviceSwiper.destroy(true, true);
+    serviceSwiper = new Swiper('.service-swiper', {
+      loop: true,
+      autoHeight: true,
+      pagination: { el: '.service-pagination', clickable: true },
+      navigation: { nextEl: '.service-next', prevEl: '.service-prev' },
+    });
+    serviceModal.classList.remove('hidden');
+  });
+});
+
+const closeService = () => serviceModal.classList.add('hidden');
+document.getElementById('close-service-modal').addEventListener('click', closeService);
+serviceModal.addEventListener('click', e => {
+  if (!e.target.closest('img') && !e.target.closest('.service-prev') && !e.target.closest('.service-next') && !e.target.closest('.service-pagination')) closeService();
+});
 </script>
 </body>
 </html>

--- a/tancy-zal-irkutsk/index.html
+++ b/tancy-zal-irkutsk/index.html
@@ -13,6 +13,7 @@
 <meta name="twitter:description" content="Почасовая аренда танцевального зала в Иркутске" />
 <meta name="twitter:image" content="https://suncitystudio.ru/img/og-image.jpg" />
 <script src="https://cdn.tailwindcss.com"></script>
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/swiper@9/swiper-bundle.min.css" />
 <script src="https://unpkg.com/lucide@latest"></script>
 <script type="application/ld+json">
 {
@@ -80,9 +81,9 @@
 <p class="mb-4">SUNCITY расположен в центре Иркутска, рядом с остановками транспорта и парковкой. Мы поддерживаем чистоту и уделяем внимание климату: в зале свежо летом и тепло зимой. Зеркала без искажений помогают отрабатывать технику, а акустика позволяет слышать каждый ритм без посторонних шумов.</p>
 <h2 class="text-2xl font-semibold mb-2">Галерея</h2>
 <div class="grid grid-cols-3 gap-2 mb-6">
-  <img src="../img/t1.webp" alt="Танцевальный зал SUNCITY Иркутск" loading="lazy" class="w-full h-40 object-cover rounded" />
-  <img src="../img/t2.webp" alt="Зал с зеркалами для танцев Иркутск" loading="lazy" class="w-full h-40 object-cover rounded" />
-  <img src="../img/t3.webp" alt="Аренда зала для танцев Иркутск" loading="lazy" class="w-full h-40 object-cover rounded" />
+  <img src="../img/t1.webp" alt="Танцевальный зал SUNCITY Иркутск" loading="lazy" data-service="dance" class="w-full aspect-[4/5] object-cover rounded cursor-pointer service-image" />
+  <img src="../img/t2.webp" alt="Зал с зеркалами для танцев Иркутск" loading="lazy" data-service="dance" class="w-full aspect-[4/5] object-cover rounded cursor-pointer service-image" />
+  <img src="../img/t3.webp" alt="Аренда зала для танцев Иркутск" loading="lazy" data-service="dance" class="w-full aspect-[4/5] object-cover rounded cursor-pointer service-image" />
 </div>
 <div class="mb-8 text-center">
   <a href="https://dikidi.ru/1321360?utm_source=site&utm_medium=button&utm_campaign=booking" target="_blank" rel="nofollow" class="inline-block bg-orange-500 text-white px-6 py-3 rounded-full">Забронировать</a>
@@ -132,6 +133,19 @@
 }
 </script>
 </main>
+
+  <!-- Service gallery modal -->
+  <div id="service-modal" class="fixed inset-0 z-50 hidden bg-black/80 flex items-center justify-center p-4">
+    <div class="relative inline-block max-w-[90vw] max-h-[90vh]">
+      <div class="swiper service-swiper">
+        <div class="swiper-wrapper" id="service-swiper-wrapper"></div>
+        <div class="swiper-pagination service-pagination"></div>
+        <div class="swiper-button-prev service-prev text-white"></div>
+        <div class="swiper-button-next service-next text-white"></div>
+      </div>
+      <button id="close-service-modal" class="absolute top-2 right-2 text-white">✕</button>
+    </div>
+  </div>
 <footer class="mt-12 border-t pt-4 text-center text-sm text-gray-500">
   <p>&copy; 2024 SUNCITY, Иркутск</p>
   <nav class="mt-2 flex justify-center space-x-4">
@@ -139,10 +153,51 @@
     <a href="/suncitystudio.ru/kontakty/" class="hover:text-orange-500">Контакты</a>
   </nav>
 </footer>
+<script src="https://cdn.jsdelivr.net/npm/swiper@9/swiper-bundle.min.js"></script>
 <script>
-const menuToggle=document.getElementById('menu-toggle');
-const mobileMenu=document.getElementById('mobile-menu');
-menuToggle.addEventListener('click',()=>mobileMenu.classList.toggle('hidden'));
+const menuToggle = document.getElementById('menu-toggle');
+const mobileMenu = document.getElementById('mobile-menu');
+menuToggle.addEventListener('click', () => mobileMenu.classList.toggle('hidden'));
+
+const base = '../img/';
+const serviceGalleries = {
+  photo: Array.from({ length: 34 }, (_, i) => `${base}f${i + 1}.webp`),
+  yoga: Array.from({ length: 3 }, (_, i) => `${base}i${i + 1}.webp`),
+  dance: Array.from({ length: 4 }, (_, i) => `${base}t${i + 1}.webp`),
+  event: Array.from({ length: 5 }, (_, i) => `${base}m${i + 1}.webp`),
+};
+serviceGalleries.all = [...serviceGalleries.photo, ...serviceGalleries.yoga, ...serviceGalleries.dance, ...serviceGalleries.event];
+
+const serviceModal = document.getElementById('service-modal');
+const serviceWrapper = document.getElementById('service-swiper-wrapper');
+let serviceSwiper;
+
+document.querySelectorAll('.service-image').forEach(img => {
+  img.addEventListener('click', () => {
+    const key = img.dataset.service;
+    serviceWrapper.innerHTML = '';
+    serviceGalleries[key].forEach(url => {
+      const slide = document.createElement('div');
+      slide.className = 'swiper-slide flex items-center justify-center';
+      slide.innerHTML = `<img src="${url}" loading="lazy" class="max-h-[90vh] max-w-[90vw] w-auto h-auto object-contain rounded" />`;
+      serviceWrapper.appendChild(slide);
+    });
+    if (serviceSwiper) serviceSwiper.destroy(true, true);
+    serviceSwiper = new Swiper('.service-swiper', {
+      loop: true,
+      autoHeight: true,
+      pagination: { el: '.service-pagination', clickable: true },
+      navigation: { nextEl: '.service-next', prevEl: '.service-prev' },
+    });
+    serviceModal.classList.remove('hidden');
+  });
+});
+
+const closeService = () => serviceModal.classList.add('hidden');
+document.getElementById('close-service-modal').addEventListener('click', closeService);
+serviceModal.addEventListener('click', e => {
+  if (!e.target.closest('img') && !e.target.closest('.service-prev') && !e.target.closest('.service-next') && !e.target.closest('.service-pagination')) closeService();
+});
 </script>
 </body>
 </html>

--- a/yoga-zal-irkutsk/index.html
+++ b/yoga-zal-irkutsk/index.html
@@ -13,6 +13,7 @@
 <meta name="twitter:description" content="Аренда зала для йоги в центре Иркутска" />
 <meta name="twitter:image" content="https://suncitystudio.ru/img/og-image.jpg" />
 <script src="https://cdn.tailwindcss.com"></script>
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/swiper@9/swiper-bundle.min.css" />
 <script src="https://unpkg.com/lucide@latest"></script>
 <script type="application/ld+json">
 {
@@ -80,9 +81,9 @@
 <p class="mb-4">Пространство подходит для индивидуальных занятий, небольших групп, йога-ретритов, дыхательных практик и релаксационных мастер-классов. Инструкторы отмечают тишину и отсутствие посторонних шумов, а ученики — ощущение уюта и свободы.</p>
 <h2 class="text-2xl font-semibold mb-2">Галерея</h2>
 <div class="grid grid-cols-3 gap-2 mb-6">
-  <img src="../img/i1.webp" alt="Зал для йоги SUNCITY Иркутск" loading="lazy" class="w-full h-40 object-cover rounded" />
-  <img src="../img/i2.webp" alt="Практика йоги в зале SUNCITY Иркутск" loading="lazy" class="w-full h-40 object-cover rounded" />
-  <img src="../img/i3.webp" alt="Аренда зала для йоги в Иркутске" loading="lazy" class="w-full h-40 object-cover rounded" />
+  <img src="../img/i1.webp" alt="Зал для йоги SUNCITY Иркутск" loading="lazy" data-service="yoga" class="w-full aspect-[4/5] object-cover rounded cursor-pointer service-image" />
+  <img src="../img/i2.webp" alt="Практика йоги в зале SUNCITY Иркутск" loading="lazy" data-service="yoga" class="w-full aspect-[4/5] object-cover rounded cursor-pointer service-image" />
+  <img src="../img/i3.webp" alt="Аренда зала для йоги в Иркутске" loading="lazy" data-service="yoga" class="w-full aspect-[4/5] object-cover rounded cursor-pointer service-image" />
 </div>
 <div class="mb-8 text-center">
   <a href="https://dikidi.ru/1321360?utm_source=site&utm_medium=button&utm_campaign=booking" target="_blank" rel="nofollow" class="inline-block bg-orange-500 text-white px-6 py-3 rounded-full">Забронировать</a>
@@ -131,6 +132,19 @@
 }
 </script>
 </main>
+
+  <!-- Service gallery modal -->
+  <div id="service-modal" class="fixed inset-0 z-50 hidden bg-black/80 flex items-center justify-center p-4">
+    <div class="relative inline-block max-w-[90vw] max-h-[90vh]">
+      <div class="swiper service-swiper">
+        <div class="swiper-wrapper" id="service-swiper-wrapper"></div>
+        <div class="swiper-pagination service-pagination"></div>
+        <div class="swiper-button-prev service-prev text-white"></div>
+        <div class="swiper-button-next service-next text-white"></div>
+      </div>
+      <button id="close-service-modal" class="absolute top-2 right-2 text-white">✕</button>
+    </div>
+  </div>
 <footer class="mt-12 border-t pt-4 text-center text-sm text-gray-500">
   <p>&copy; 2024 SUNCITY, Иркутск</p>
   <nav class="mt-2 flex justify-center space-x-4">
@@ -138,10 +152,51 @@
     <a href="/suncitystudio.ru/kontakty/" class="hover:text-orange-500">Контакты</a>
   </nav>
 </footer>
+<script src="https://cdn.jsdelivr.net/npm/swiper@9/swiper-bundle.min.js"></script>
 <script>
-const menuToggle=document.getElementById('menu-toggle');
-const mobileMenu=document.getElementById('mobile-menu');
-menuToggle.addEventListener('click',()=>mobileMenu.classList.toggle('hidden'));
+const menuToggle = document.getElementById('menu-toggle');
+const mobileMenu = document.getElementById('mobile-menu');
+menuToggle.addEventListener('click', () => mobileMenu.classList.toggle('hidden'));
+
+const base = '../img/';
+const serviceGalleries = {
+  photo: Array.from({ length: 34 }, (_, i) => `${base}f${i + 1}.webp`),
+  yoga: Array.from({ length: 3 }, (_, i) => `${base}i${i + 1}.webp`),
+  dance: Array.from({ length: 4 }, (_, i) => `${base}t${i + 1}.webp`),
+  event: Array.from({ length: 5 }, (_, i) => `${base}m${i + 1}.webp`),
+};
+serviceGalleries.all = [...serviceGalleries.photo, ...serviceGalleries.yoga, ...serviceGalleries.dance, ...serviceGalleries.event];
+
+const serviceModal = document.getElementById('service-modal');
+const serviceWrapper = document.getElementById('service-swiper-wrapper');
+let serviceSwiper;
+
+document.querySelectorAll('.service-image').forEach(img => {
+  img.addEventListener('click', () => {
+    const key = img.dataset.service;
+    serviceWrapper.innerHTML = '';
+    serviceGalleries[key].forEach(url => {
+      const slide = document.createElement('div');
+      slide.className = 'swiper-slide flex items-center justify-center';
+      slide.innerHTML = `<img src="${url}" loading="lazy" class="max-h-[90vh] max-w-[90vw] w-auto h-auto object-contain rounded" />`;
+      serviceWrapper.appendChild(slide);
+    });
+    if (serviceSwiper) serviceSwiper.destroy(true, true);
+    serviceSwiper = new Swiper('.service-swiper', {
+      loop: true,
+      autoHeight: true,
+      pagination: { el: '.service-pagination', clickable: true },
+      navigation: { nextEl: '.service-next', prevEl: '.service-prev' },
+    });
+    serviceModal.classList.remove('hidden');
+  });
+});
+
+const closeService = () => serviceModal.classList.add('hidden');
+document.getElementById('close-service-modal').addEventListener('click', closeService);
+serviceModal.addEventListener('click', e => {
+  if (!e.target.closest('img') && !e.target.closest('.service-prev') && !e.target.closest('.service-next') && !e.target.closest('.service-pagination')) closeService();
+});
 </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- enable Swiper modal galleries on all service pages
- use wider image format and themed image sets for each page

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a72b2e690c832cb4ef9f18ffe28494