### PR TITLE
Fix icons and restore navigation

### DIFF
--- a/arenda-zala-irkutsk/index.html
+++ b/arenda-zala-irkutsk/index.html
@@ -260,26 +260,7 @@
   {"@type":"ListItem","position":2,"name":"Аренда зала","item":"https://suncitystudio.ru/arenda-zala-irkutsk/"}
  ]
 }
-</script>
-<script type="application/ld+json">
-{
- "@context":"https://schema.org",
- "@type":"FAQPage",
- "mainEntity":[
-  {"@type":"Question","name":"Перенести/отменить бронь?","acceptedAnswer":{"@type":"Answer","text":"Бесплатно ≥24 ч. <24 ч - по согласованию, перенос не гарантируется."}},
-  {"@type":"Question","name":"Есть ли реквизит?","acceptedAnswer":{"@type":"Answer","text":"Да: кресла, журнальные столики, передвижные зеркала, камин, цветы, коврики, колонка, свет, крюки для йоги"}},
-  {"@type":"Question","name":"Где находимся?","acceptedAnswer":{"@type":"Answer","text":"Байкальская, 19А, 5 этаж, вход с торца слева (рядом находится ТЦ «Карамель»). Есть парковка."}},
-  {"@type":"Question","name":"Как забронировать?","acceptedAnswer":{"@type":"Answer","text":"Через онлайн сервис Dikidi - видны свободные слоты."}},
-  {"@type":"Question","name":"Со своей едой?","acceptedAnswer":{"@type":"Answer","text":"Да, аккуратно: без сильных запахов/окраски. Свечи/конфетти - по согласованию."}},
-  {"@type":"Question","name":"Сколько людей войдет?","acceptedAnswer":{"@type":"Answer","text":"42 м²: съёмки до 10, занятия комфортно до 10-12 человек."}},
-  {"@type":"Question","name":"Продлить на месте?","acceptedAnswer":{"@type":"Answer","text":"Если есть окно - да, оплата по факту."}},
-  {"@type":"Question","name":"Музыка?","acceptedAnswer":{"@type":"Answer","text":"Bluetooth-колонка, подключение с телефона."}},
-  {"@type":"Question","name":"Обувь/покрытие?","acceptedAnswer":{"@type":"Answer","text":"Сменка/носки; качественный ламинат."}},
-  {"@type":"Question","name":"Дети/питомцы?","acceptedAnswer":{"@type":"Answer","text":"По согласованию."}}
- ]
-}
-</script>
-
+ </script>
 
 
 </main>
@@ -349,5 +330,6 @@ serviceModal.addEventListener('click', e => {
   if (!e.target.closest('img') && !e.target.closest('.service-prev') && !e.target.closest('.service-next') && !e.target.closest('.service-pagination')) closeService();
 });
 </script>
+<script>lucide.createIcons();</script>
 </body>
 </html>

--- a/ceny/index.html
+++ b/ceny/index.html
@@ -230,6 +230,21 @@
   </details>
 </div>
 
+<h2 class="text-2xl font-semibold mb-4">Читайте также</h2>
+<ul class="list-disc list-inside mb-8">
+  <li><a href="/suncitystudio.ru/" class="text-orange-500 hover:underline">Главная</a></li>
+  <li><a href="/suncitystudio.ru/arenda-zala-irkutsk/" class="text-orange-500 hover:underline">Аренда зала</a></li>
+  <li><a href="/suncitystudio.ru/fotостudiya-irkutsk/" class="text-orange-500 hover:underline">Фотостудия</a></li>
+  <li><a href="/suncitystudio.ru/gender-party-irkutsk/" class="text-orange-500 hover:underline">Гендер-пати</a></li>
+  <li><a href="/suncitystudio.ru/yoga-zal-irkutsk/" class="text-orange-500 hover:underline">Йога</a></li>
+  <li><a href="/suncitystudio.ru/tancy-zal-irkutsk/" class="text-orange-500 hover:underline">Танцы</a></li>
+  <li><a href="/suncitystudio.ru/fly-yoga-irkutsk/" class="text-orange-500 hover:underline">Fly-йога</a></li>
+  <li><a href="/suncitystudio.ru/meropriyatiya-irkutsk/" class="text-orange-500 hover:underline">Мероприятия</a></li>
+  <li><a href="/suncitystudio.ru/ceny/" class="text-orange-500 hover:underline">Цены</a></li>
+  <li><a href="/suncitystudio.ru/pravila/" class="text-orange-500 hover:underline">Правила</a></li>
+  <li><a href="/suncitystudio.ru/kontakty/" class="text-orange-500 hover:underline">Контакты</a></li>
+</ul>
+
 <script type="application/ld+json">
 {
  "@context":"https://schema.org",
@@ -237,24 +252,6 @@
  "itemListElement":[
   {"@type":"ListItem","position":1,"name":"Главная","item":"https://suncitystudio.ru/"},
   {"@type":"ListItem","position":2,"name":"Цены","item":"https://suncitystudio.ru/ceny/"}
- ]
-}
-</script>
-<script type="application/ld+json">
-{
- "@context":"https://schema.org",
- "@type":"FAQPage",
- "mainEntity":[
-  {"@type":"Question","name":"Перенести/отменить бронь?","acceptedAnswer":{"@type":"Answer","text":"Бесплатно ≥24 ч. <24 ч - по согласованию, перенос не гарантируется."}},
-  {"@type":"Question","name":"Есть ли реквизит?","acceptedAnswer":{"@type":"Answer","text":"Да: кресла, журнальные столики, передвижные зеркала, камин, цветы, коврики, колонка, свет, крюки для йоги"}},
-  {"@type":"Question","name":"Где находимся?","acceptedAnswer":{"@type":"Answer","text":"Байкальская, 19А, 5 этаж, вход с торца слева (рядом находится ТЦ «Карамель»). Есть парковка."}},
-  {"@type":"Question","name":"Как забронировать?","acceptedAnswer":{"@type":"Answer","text":"Через онлайн сервис Dikidi - видны свободные слоты."}},
-  {"@type":"Question","name":"Со своей едой?","acceptedAnswer":{"@type":"Answer","text":"Да, аккуратно: без сильных запахов/окраски. Свечи/конфетти - по согласованию."}},
-  {"@type":"Question","name":"Сколько людей войдет?","acceptedAnswer":{"@type":"Answer","text":"42 м²: съёмки до 10, занятия комфортно до 10-12 человек."}},
-  {"@type":"Question","name":"Продлить на месте?","acceptedAnswer":{"@type":"Answer","text":"Если есть окно - да, оплата по факту."}},
-  {"@type":"Question","name":"Музыка?","acceptedAnswer":{"@type":"Answer","text":"Bluetooth-колонка, подключение с телефона."}},
-  {"@type":"Question","name":"Обувь/покрытие?","acceptedAnswer":{"@type":"Answer","text":"Сменка/носки; качественный ламинат."}},
-  {"@type":"Question","name":"Дети/питомцы?","acceptedAnswer":{"@type":"Answer","text":"По согласованию."}}
  ]
 }
 </script>
@@ -285,8 +282,9 @@ document.addEventListener('DOMContentLoaded',()=>{
   const s=document.createElement('script');
   s.type='application/ld+json';
   s.text=JSON.stringify(ld);
-  document.head.appendChild(s);
+document.head.appendChild(s);
 });
 </script>
+<script>lucide.createIcons();</script>
 </body>
 </html>

--- a/fly-yoga-irkutsk/index.html
+++ b/fly-yoga-irkutsk/index.html
@@ -233,34 +233,32 @@
   </details>
 </div>
 
-<script type="application/ld+json">
-{
- "@context":"https://schema.org",
- "@type":"BreadcrumbList",
- "itemListElement":[
-  {"@type":"ListItem","position":1,"name":"Главная","item":"https://suncitystudio.ru/"},
-  {"@type":"ListItem","position":2,"name":"Флай-йога","item":"https://suncitystudio.ru/fly-yoga-irkutsk/"}
- ]
-}
-</script>
-<script type="application/ld+json">
-{
- "@context":"https://schema.org",
- "@type":"FAQPage",
- "mainEntity":[
-  {"@type":"Question","name":"Перенести/отменить бронь?","acceptedAnswer":{"@type":"Answer","text":"Бесплатно ≥24 ч. <24 ч - по согласованию, перенос не гарантируется."}},
-  {"@type":"Question","name":"Есть ли реквизит?","acceptedAnswer":{"@type":"Answer","text":"Да: кресла, журнальные столики, передвижные зеркала, камин, цветы, коврики, колонка, свет, крюки для йоги"}},
-  {"@type":"Question","name":"Где находимся?","acceptedAnswer":{"@type":"Answer","text":"Байкальская, 19А, 5 этаж, вход с торца слева (рядом находится ТЦ «Карамель»). Есть парковка."}},
-  {"@type":"Question","name":"Как забронировать?","acceptedAnswer":{"@type":"Answer","text":"Через онлайн сервис Dikidi - видны свободные слоты."}},
-  {"@type":"Question","name":"Со своей едой?","acceptedAnswer":{"@type":"Answer","text":"Да, аккуратно: без сильных запахов/окраски. Свечи/конфетти - по согласованию."}},
-  {"@type":"Question","name":"Сколько людей войдет?","acceptedAnswer":{"@type":"Answer","text":"42 м²: съёмки до 10, занятия комфортно до 10-12 человек."}},
-  {"@type":"Question","name":"Продлить на месте?","acceptedAnswer":{"@type":"Answer","text":"Если есть окно - да, оплата по факту."}},
-  {"@type":"Question","name":"Музыка?","acceptedAnswer":{"@type":"Answer","text":"Bluetooth-колонка, подключение с телефона."}},
-  {"@type":"Question","name":"Обувь/покрытие?","acceptedAnswer":{"@type":"Answer","text":"Сменка/носки; качественный ламинат."}},
-  {"@type":"Question","name":"Дети/питомцы?","acceptedAnswer":{"@type":"Answer","text":"По согласованию."}}
- ]
-}
-</script>
+ 
+  <h2 class="text-2xl font-semibold mb-4">Читайте также</h2>
+  <ul class="list-disc list-inside mb-8">
+    <li><a href="/suncitystudio.ru/" class="text-orange-500 hover:underline">Главная</a></li>
+    <li><a href="/suncitystudio.ru/arenda-zala-irkutsk/" class="text-orange-500 hover:underline">Аренда зала</a></li>
+    <li><a href="/suncitystudio.ru/fotostudiya-irkutsk/" class="text-orange-500 hover:underline">Фотостудия</a></li>
+    <li><a href="/suncitystudio.ru/gender-party-irkutsk/" class="text-orange-500 hover:underline">Гендер-пати</a></li>
+    <li><a href="/suncitystudio.ru/yoga-zal-irkutsk/" class="text-orange-500 hover:underline">Йога</a></li>
+    <li><a href="/suncitystudio.ru/tancy-zal-irkutsk/" class="text-orange-500 hover:underline">Танцы</a></li>
+    <li><a href="/suncitystudio.ru/fly-yoga-irkutsk/" class="text-orange-500 hover:underline">Fly-йога</a></li>
+    <li><a href="/suncitystudio.ru/meropriyatiya-irkutsk/" class="text-orange-500 hover:underline">Мероприятия</a></li>
+    <li><a href="/suncitystudio.ru/ceny/" class="text-orange-500 hover:underline">Цены</a></li>
+    <li><a href="/suncitystudio.ru/pravila/" class="text-orange-500 hover:underline">Правила</a></li>
+    <li><a href="/suncitystudio.ru/kontakty/" class="text-orange-500 hover:underline">Контакты</a></li>
+  </ul>
+
+  <script type="application/ld+json">
+  {
+   "@context":"https://schema.org",
+   "@type":"BreadcrumbList",
+   "itemListElement":[
+    {"@type":"ListItem","position":1,"name":"Главная","item":"https://suncitystudio.ru/"},
+    {"@type":"ListItem","position":2,"name":"Флай-йога","item":"https://suncitystudio.ru/fly-yoga-irkutsk/"}
+   ]
+  }
+  </script>
 
 
 
@@ -331,5 +329,6 @@ serviceModal.addEventListener('click', e => {
   if (!e.target.closest('img') && !e.target.closest('.service-prev') && !e.target.closest('.service-next') && !e.target.closest('.service-pagination')) closeService();
 });
 </script>
+<script>lucide.createIcons();</script>
 </body>
 </html>

--- a/fotostudiya-irkutsk/index.html
+++ b/fotostudiya-irkutsk/index.html
@@ -234,36 +234,33 @@
       </details>
     </div>
   </details>
-</div>
+  </div>
 
-<script type="application/ld+json">
-{
- "@context":"https://schema.org",
- "@type":"BreadcrumbList",
- "itemListElement":[
-  {"@type":"ListItem","position":1,"name":"Главная","item":"https://suncitystudio.ru/"},
-  {"@type":"ListItem","position":2,"name":"Фотостудия","item":"https://suncitystudio.ru/fotostudiya-irkutsk/"}
- ]
-}
-</script>
-<script type="application/ld+json">
-{
- "@context":"https://schema.org",
- "@type":"FAQPage",
- "mainEntity":[
-  {"@type":"Question","name":"Перенести/отменить бронь?","acceptedAnswer":{"@type":"Answer","text":"Бесплатно ≥24 ч. <24 ч - по согласованию, перенос не гарантируется."}},
-  {"@type":"Question","name":"Есть ли реквизит?","acceptedAnswer":{"@type":"Answer","text":"Да: кресла, журнальные столики, передвижные зеркала, камин, цветы, коврики, колонка, свет, крюки для йоги"}},
-  {"@type":"Question","name":"Где находимся?","acceptedAnswer":{"@type":"Answer","text":"Байкальская, 19А, 5 этаж, вход с торца слева (рядом находится ТЦ «Карамель»). Есть парковка."}},
-  {"@type":"Question","name":"Как забронировать?","acceptedAnswer":{"@type":"Answer","text":"Через онлайн сервис Dikidi - видны свободные слоты."}},
-  {"@type":"Question","name":"Со своей едой?","acceptedAnswer":{"@type":"Answer","text":"Да, аккуратно: без сильных запахов/окраски. Свечи/конфетти - по согласованию."}},
-  {"@type":"Question","name":"Сколько людей войдет?","acceptedAnswer":{"@type":"Answer","text":"42 м²: съёмки до 10, занятия комфортно до 10-12 человек."}},
-  {"@type":"Question","name":"Продлить на месте?","acceptedAnswer":{"@type":"Answer","text":"Если есть окно - да, оплата по факту."}},
-  {"@type":"Question","name":"Музыка?","acceptedAnswer":{"@type":"Answer","text":"Bluetooth-колонка, подключение с телефона."}},
-  {"@type":"Question","name":"Обувь/покрытие?","acceptedAnswer":{"@type":"Answer","text":"Сменка/носки; качественный ламинат."}},
-  {"@type":"Question","name":"Дети/питомцы?","acceptedAnswer":{"@type":"Answer","text":"По согласованию."}}
- ]
-}
-</script>
+  <h2 class="text-2xl font-semibold mb-4">Читайте также</h2>
+  <ul class="list-disc list-inside mb-8">
+    <li><a href="/suncitystudio.ru/" class="text-orange-500 hover:underline">Главная</a></li>
+    <li><a href="/suncitystudio.ru/arenda-zala-irkutsk/" class="text-orange-500 hover:underline">Аренда зала</a></li>
+    <li><a href="/suncitystudio.ru/fotostudiya-irkutsk/" class="text-orange-500 hover:underline">Фотостудия</a></li>
+    <li><a href="/suncitystudio.ru/gender-party-irkutsk/" class="text-orange-500 hover:underline">Гендер-пати</a></li>
+    <li><a href="/suncitystudio.ru/yoga-zal-irkutsk/" class="text-orange-500 hover:underline">Йога</a></li>
+    <li><a href="/suncitystudio.ru/tancy-zal-irkutsk/" class="text-orange-500 hover:underline">Танцы</a></li>
+    <li><a href="/suncitystudio.ru/fly-yoga-irkutsk/" class="text-orange-500 hover:underline">Fly-йога</a></li>
+    <li><a href="/suncitystudio.ru/meropriyatiya-irkutsk/" class="text-orange-500 hover:underline">Мероприятия</a></li>
+    <li><a href="/suncitystudio.ru/ceny/" class="text-orange-500 hover:underline">Цены</a></li>
+    <li><a href="/suncitystudio.ru/pravila/" class="text-orange-500 hover:underline">Правила</a></li>
+    <li><a href="/suncitystudio.ru/kontakty/" class="text-orange-500 hover:underline">Контакты</a></li>
+  </ul>
+
+  <script type="application/ld+json">
+  {
+   "@context":"https://schema.org",
+   "@type":"BreadcrumbList",
+   "itemListElement":[
+    {"@type":"ListItem","position":1,"name":"Главная","item":"https://suncitystudio.ru/"},
+    {"@type":"ListItem","position":2,"name":"Фотостудия","item":"https://suncitystudio.ru/fotostudiya-irkutsk/"}
+   ]
+  }
+  </script>
 
 
 
@@ -334,5 +331,6 @@ serviceModal.addEventListener('click', e => {
   if (!e.target.closest('img') && !e.target.closest('.service-prev') && !e.target.closest('.service-next') && !e.target.closest('.service-pagination')) closeService();
 });
 </script>
+<script>lucide.createIcons();</script>
 </body>
 </html>

--- a/gender-party-irkutsk/index.html
+++ b/gender-party-irkutsk/index.html
@@ -235,34 +235,32 @@
   </details>
 </div>
 
-<script type="application/ld+json">
-{
- "@context":"https://schema.org",
- "@type":"BreadcrumbList",
- "itemListElement":[
-  {"@type":"ListItem","position":1,"name":"Главная","item":"https://suncitystudio.ru/"},
-  {"@type":"ListItem","position":2,"name":"Гендер-пати","item":"https://suncitystudio.ru/gender-party-irkutsk/"}
- ]
-}
-</script>
-<script type="application/ld+json">
-{
- "@context":"https://schema.org",
- "@type":"FAQPage",
- "mainEntity":[
-  {"@type":"Question","name":"Перенести/отменить бронь?","acceptedAnswer":{"@type":"Answer","text":"Бесплатно ≥24 ч. <24 ч - по согласованию, перенос не гарантируется."}},
-  {"@type":"Question","name":"Есть ли реквизит?","acceptedAnswer":{"@type":"Answer","text":"Да: кресла, журнальные столики, передвижные зеркала, камин, цветы, коврики, колонка, свет, крюки для йоги"}},
-  {"@type":"Question","name":"Где находимся?","acceptedAnswer":{"@type":"Answer","text":"Байкальская, 19А, 5 этаж, вход с торца слева (рядом находится ТЦ «Карамель»). Есть парковка."}},
-  {"@type":"Question","name":"Как забронировать?","acceptedAnswer":{"@type":"Answer","text":"Через онлайн сервис Dikidi - видны свободные слоты."}},
-  {"@type":"Question","name":"Со своей едой?","acceptedAnswer":{"@type":"Answer","text":"Да, аккуратно: без сильных запахов/окраски. Свечи/конфетти - по согласованию."}},
-  {"@type":"Question","name":"Сколько людей войдет?","acceptedAnswer":{"@type":"Answer","text":"42 м²: съёмки до 10, занятия комфортно до 10-12 человек."}},
-  {"@type":"Question","name":"Продлить на месте?","acceptedAnswer":{"@type":"Answer","text":"Если есть окно - да, оплата по факту."}},
-  {"@type":"Question","name":"Музыка?","acceptedAnswer":{"@type":"Answer","text":"Bluetooth-колонка, подключение с телефона."}},
-  {"@type":"Question","name":"Обувь/покрытие?","acceptedAnswer":{"@type":"Answer","text":"Сменка/носки; качественный ламинат."}},
-  {"@type":"Question","name":"Дети/питомцы?","acceptedAnswer":{"@type":"Answer","text":"По согласованию."}}
- ]
-}
-</script>
+ 
+  <h2 class="text-2xl font-semibold mb-4">Читайте также</h2>
+  <ul class="list-disc list-inside mb-8">
+    <li><a href="/suncitystudio.ru/" class="text-orange-500 hover:underline">Главная</a></li>
+    <li><a href="/suncitystudio.ru/arenda-zala-irkutsk/" class="text-orange-500 hover:underline">Аренда зала</a></li>
+    <li><a href="/suncitystudio.ru/fotostudiya-irkutsk/" class="text-orange-500 hover:underline">Фотостудия</a></li>
+    <li><a href="/suncitystudio.ru/gender-party-irkutsk/" class="text-orange-500 hover:underline">Гендер-пати</a></li>
+    <li><a href="/suncitystudio.ru/yoga-zal-irkutsk/" class="text-orange-500 hover:underline">Йога</a></li>
+    <li><a href="/suncitystudio.ru/tancy-zal-irkutsk/" class="text-orange-500 hover:underline">Танцы</a></li>
+    <li><a href="/suncitystudio.ru/fly-yoga-irkutsk/" class="text-orange-500 hover:underline">Fly-йога</a></li>
+    <li><a href="/suncitystudio.ru/meropriyatiya-irkutsk/" class="text-orange-500 hover:underline">Мероприятия</a></li>
+    <li><a href="/suncitystudio.ru/ceny/" class="text-orange-500 hover:underline">Цены</a></li>
+    <li><a href="/suncitystudio.ru/pravila/" class="text-orange-500 hover:underline">Правила</a></li>
+    <li><a href="/suncitystudio.ru/kontakty/" class="text-orange-500 hover:underline">Контакты</a></li>
+  </ul>
+
+  <script type="application/ld+json">
+  {
+   "@context":"https://schema.org",
+   "@type":"BreadcrumbList",
+   "itemListElement":[
+    {"@type":"ListItem","position":1,"name":"Главная","item":"https://suncitystudio.ru/"},
+    {"@type":"ListItem","position":2,"name":"Гендер-пати","item":"https://suncitystudio.ru/gender-party-irkutsk/"}
+   ]
+  }
+  </script>
 
 
 
@@ -333,5 +331,6 @@ serviceModal.addEventListener('click', e => {
   if (!e.target.closest('img') && !e.target.closest('.service-prev') && !e.target.closest('.service-next') && !e.target.closest('.service-pagination')) closeService();
 });
 </script>
+<script>lucide.createIcons();</script>
 </body>
 </html>

--- a/kontakty/index.html
+++ b/kontakty/index.html
@@ -54,6 +54,21 @@
 <p class="mb-4">Студия расположена на третьем этаже бизнес-центра. Вход через главный ресепшен, затем лифт или лестница. Если едете на машине, удобная парковка находится за зданием.</p>
 <h2 class="text-2xl font-semibold mb-2">Связь</h2>
 <p>Вы можете написать нам в <a href="https://wa.me/79025101206?utm_source=site&utm_medium=button&utm_campaign=booking" target="_blank" rel="nofollow" class="text-orange-500">WhatsApp</a> или <a href="https://t.me/yousee_this?utm_source=site&utm_medium=button&utm_campaign=booking" target="_blank" rel="nofollow" class="text-orange-500">Telegram</a>, а также забронировать время через <a href="https://dikidi.ru/1321360?utm_source=site&utm_medium=button&utm_campaign=booking" target="_blank" rel="nofollow" class="text-orange-500">Dikidi</a>.</p>
+<h2 class="text-2xl font-semibold mb-4">Читайте также</h2>
+<ul class="list-disc list-inside mb-8">
+  <li><a href="/suncitystudio.ru/" class="text-orange-500 hover:underline">Главная</a></li>
+  <li><a href="/suncitystudio.ru/arenda-zala-irkutsk/" class="text-orange-500 hover:underline">Аренда зала</a></li>
+  <li><a href="/suncitystudio.ru/fotostudiya-irkutsk/" class="text-orange-500 hover:underline">Фотостудия</a></li>
+  <li><a href="/suncitystudio.ru/gender-party-irkutsk/" class="text-orange-500 hover:underline">Гендер-пати</a></li>
+  <li><a href="/suncitystudio.ru/yoga-zal-irkutsk/" class="text-orange-500 hover:underline">Йога</a></li>
+  <li><a href="/suncitystudio.ru/tancy-zal-irkutsk/" class="text-orange-500 hover:underline">Танцы</a></li>
+  <li><a href="/suncitystudio.ru/fly-yoga-irkutsk/" class="text-orange-500 hover:underline">Fly-йога</a></li>
+  <li><a href="/suncitystudio.ru/meropriyatiya-irkutsk/" class="text-orange-500 hover:underline">Мероприятия</a></li>
+  <li><a href="/suncitystudio.ru/ceny/" class="text-orange-500 hover:underline">Цены</a></li>
+  <li><a href="/suncitystudio.ru/pravila/" class="text-orange-500 hover:underline">Правила</a></li>
+  <li><a href="/suncitystudio.ru/kontakty/" class="text-orange-500 hover:underline">Контакты</a></li>
+</ul>
+
 <script type="application/ld+json">
 {
  "@context":"https://schema.org",
@@ -77,5 +92,6 @@ const menuToggle=document.getElementById('menu-toggle');
 const mobileMenu=document.getElementById('mobile-menu');
 menuToggle.addEventListener('click',()=>mobileMenu.classList.toggle('hidden'));
 </script>
+<script>lucide.createIcons();</script>
 </body>
 </html>

--- a/meropriyatiya-irkutsk/index.html
+++ b/meropriyatiya-irkutsk/index.html
@@ -235,34 +235,31 @@
   </details>
 </div>
 
-<script type="application/ld+json">
-{
- "@context":"https://schema.org",
- "@type":"BreadcrumbList",
- "itemListElement":[
-  {"@type":"ListItem","position":1,"name":"Главная","item":"https://suncitystudio.ru/"},
-  {"@type":"ListItem","position":2,"name":"Мероприятия","item":"https://suncitystudio.ru/meropriyatiya-irkutsk/"}
- ]
-}
-</script>
-<script type="application/ld+json">
-{
- "@context":"https://schema.org",
- "@type":"FAQPage",
- "mainEntity":[
-  {"@type":"Question","name":"Перенести/отменить бронь?","acceptedAnswer":{"@type":"Answer","text":"Бесплатно ≥24 ч. <24 ч - по согласованию, перенос не гарантируется."}},
-  {"@type":"Question","name":"Есть ли реквизит?","acceptedAnswer":{"@type":"Answer","text":"Да: кресла, журнальные столики, передвижные зеркала, камин, цветы, коврики, колонка, свет, крюки для йоги"}},
-  {"@type":"Question","name":"Где находимся?","acceptedAnswer":{"@type":"Answer","text":"Байкальская, 19А, 5 этаж, вход с торца слева (рядом находится ТЦ «Карамель»). Есть парковка."}},
-  {"@type":"Question","name":"Как забронировать?","acceptedAnswer":{"@type":"Answer","text":"Через онлайн сервис Dikidi - видны свободные слоты."}},
-  {"@type":"Question","name":"Со своей едой?","acceptedAnswer":{"@type":"Answer","text":"Да, аккуратно: без сильных запахов/окраски. Свечи/конфетти - по согласованию."}},
-  {"@type":"Question","name":"Сколько людей войдет?","acceptedAnswer":{"@type":"Answer","text":"42 м²: съёмки до 10, занятия комфортно до 10-12 человек."}},
-  {"@type":"Question","name":"Продлить на месте?","acceptedAnswer":{"@type":"Answer","text":"Если есть окно - да, оплата по факту."}},
-  {"@type":"Question","name":"Музыка?","acceptedAnswer":{"@type":"Answer","text":"Bluetooth-колонка, подключение с телефона."}},
-  {"@type":"Question","name":"Обувь/покрытие?","acceptedAnswer":{"@type":"Answer","text":"Сменка/носки; качественный ламинат."}},
-  {"@type":"Question","name":"Дети/питомцы?","acceptedAnswer":{"@type":"Answer","text":"По согласованию."}}
- ]
-}
-</script>
+  <h2 class="text-2xl font-semibold mb-4">Читайте также</h2>
+  <ul class="list-disc list-inside mb-8">
+    <li><a href="/suncitystudio.ru/" class="text-orange-500 hover:underline">Главная</a></li>
+    <li><a href="/suncitystudio.ru/arenda-zala-irkutsk/" class="text-orange-500 hover:underline">Аренда зала</a></li>
+    <li><a href="/suncitystudio.ru/fotostudiya-irkutsk/" class="text-orange-500 hover:underline">Фотостудия</a></li>
+    <li><a href="/suncitystudio.ru/gender-party-irkutsk/" class="text-orange-500 hover:underline">Гендер-пати</a></li>
+    <li><a href="/suncitystudio.ru/yoga-zal-irkutsk/" class="text-orange-500 hover:underline">Йога</a></li>
+    <li><a href="/suncitystudio.ru/tancy-zal-irkutsk/" class="text-orange-500 hover:underline">Танцы</a></li>
+    <li><a href="/suncitystudio.ru/fly-yoga-irkutsk/" class="text-orange-500 hover:underline">Fly-йога</a></li>
+    <li><a href="/suncitystudio.ru/meropriyatiya-irkutsk/" class="text-orange-500 hover:underline">Мероприятия</a></li>
+    <li><a href="/suncitystudio.ru/ceny/" class="text-orange-500 hover:underline">Цены</a></li>
+    <li><a href="/suncitystudio.ru/pravila/" class="text-orange-500 hover:underline">Правила</a></li>
+    <li><a href="/suncitystudio.ru/kontakty/" class="text-orange-500 hover:underline">Контакты</a></li>
+  </ul>
+
+  <script type="application/ld+json">
+  {
+   "@context":"https://schema.org",
+   "@type":"BreadcrumbList",
+   "itemListElement":[
+    {"@type":"ListItem","position":1,"name":"Главная","item":"https://suncitystudio.ru/"},
+    {"@type":"ListItem","position":2,"name":"Мероприятия","item":"https://suncitystudio.ru/meropriyatiya-irkutsk/"}
+   ]
+  }
+  </script>
 
 
 
@@ -333,5 +330,6 @@ serviceModal.addEventListener('click', e => {
   if (!e.target.closest('img') && !e.target.closest('.service-prev') && !e.target.closest('.service-next') && !e.target.closest('.service-pagination')) closeService();
 });
 </script>
+<script>lucide.createIcons();</script>
 </body>
 </html>

--- a/pravila/index.html
+++ b/pravila/index.html
@@ -84,8 +84,23 @@
 <p class="mb-4">С 08:00 до 22:00 разрешены любые занятия. После 22:00 просим снизить уровень шума и громкость музыки, чтобы не мешать соседям. Запрещено использовать пиротехнику и дымовые машины без согласования.</p>
 <h2 class="text-2xl font-semibold mb-2">Оплата и ответственность</h2>
 <p class="mb-4">Оплата производится до начала аренды наличными, переводом или по счёту. В случае повреждения имущества арендаторы возмещают стоимость ремонта. Мы не несём ответственность за вещи, оставленные без присмотра.</p>
+<h2 class="text-2xl font-semibold mb-4">Читайте также</h2>
+<ul class="list-disc list-inside mb-8">
+  <li><a href="/suncitystudio.ru/" class="text-orange-500 hover:underline">Главная</a></li>
+  <li><a href="/suncitystudio.ru/arenda-zala-irkutsk/" class="text-orange-500 hover:underline">Аренда зала</a></li>
+  <li><a href="/suncitystudio.ru/fotostudiya-irkutsk/" class="text-orange-500 hover:underline">Фотостудия</a></li>
+  <li><a href="/suncitystudio.ru/gender-party-irkutsk/" class="text-orange-500 hover:underline">Гендер-пати</a></li>
+  <li><a href="/suncitystudio.ru/yoga-zal-irkutsk/" class="text-orange-500 hover:underline">Йога</a></li>
+  <li><a href="/suncitystudio.ru/tancy-zal-irkutsk/" class="text-orange-500 hover:underline">Танцы</a></li>
+  <li><a href="/suncitystudio.ru/fly-yoga-irkutsk/" class="text-orange-500 hover:underline">Fly-йога</a></li>
+  <li><a href="/suncitystudio.ru/meropriyatiya-irkutsk/" class="text-orange-500 hover:underline">Мероприятия</a></li>
+  <li><a href="/suncitystudio.ru/ceny/" class="text-orange-500 hover:underline">Цены</a></li>
+  <li><a href="/suncitystudio.ru/pravila/" class="text-orange-500 hover:underline">Правила</a></li>
+  <li><a href="/suncitystudio.ru/kontakty/" class="text-orange-500 hover:underline">Контакты</a></li>
+</ul>
+
 <script type="application/ld+json">
-{
+{ 
  "@context":"https://schema.org",
 
  "@type":"BreadcrumbList",
@@ -108,5 +123,6 @@ const menuToggle=document.getElementById('menu-toggle');
 const mobileMenu=document.getElementById('mobile-menu');
 menuToggle.addEventListener('click',()=>mobileMenu.classList.toggle('hidden'));
 </script>
+<script>lucide.createIcons();</script>
 </body>
 </html>

--- a/tancy-zal-irkutsk/index.html
+++ b/tancy-zal-irkutsk/index.html
@@ -234,35 +234,31 @@
   </details>
 </div>
 
-<script type="application/ld+json">
-{
- "@context":"https://schema.org",
+  <h2 class="text-2xl font-semibold mb-4">Читайте также</h2>
+  <ul class="list-disc list-inside mb-8">
+    <li><a href="/suncitystudio.ru/" class="text-orange-500 hover:underline">Главная</a></li>
+    <li><a href="/suncitystudio.ru/arenda-zala-irkutsk/" class="text-orange-500 hover:underline">Аренда зала</a></li>
+    <li><a href="/suncitystudio.ru/fotostudiya-irkutsk/" class="text-orange-500 hover:underline">Фотостудия</a></li>
+    <li><a href="/suncitystudio.ru/gender-party-irkutsk/" class="text-orange-500 hover:underline">Гендер-пати</a></li>
+    <li><a href="/suncitystudio.ru/yoga-zal-irkutsk/" class="text-orange-500 hover:underline">Йога</a></li>
+    <li><a href="/suncitystudio.ru/tancy-zal-irkutsk/" class="text-orange-500 hover:underline">Танцы</a></li>
+    <li><a href="/suncitystudio.ru/fly-yoga-irkutsk/" class="text-orange-500 hover:underline">Fly-йога</a></li>
+    <li><a href="/suncitystudio.ru/meropriyatiya-irkutsk/" class="text-orange-500 hover:underline">Мероприятия</a></li>
+    <li><a href="/suncitystudio.ru/ceny/" class="text-orange-500 hover:underline">Цены</a></li>
+    <li><a href="/suncitystudio.ru/pravila/" class="text-orange-500 hover:underline">Правила</a></li>
+    <li><a href="/suncitystudio.ru/kontakty/" class="text-orange-500 hover:underline">Контакты</a></li>
+  </ul>
 
- "@type":"BreadcrumbList",
- "itemListElement":[
-  {"@type":"ListItem","position":1,"name":"Главная","item":"https://suncitystudio.ru/"},
-  {"@type":"ListItem","position":2,"name":"Зал для танцев","item":"https://suncitystudio.ru/tancy-zal-irkutsk/"}
- ]
-}
-</script>
-<script type="application/ld+json">
-{
- "@context":"https://schema.org",
- "@type":"FAQPage",
- "mainEntity":[
-  {"@type":"Question","name":"Перенести/отменить бронь?","acceptedAnswer":{"@type":"Answer","text":"Бесплатно ≥24 ч. <24 ч - по согласованию, перенос не гарантируется."}},
-  {"@type":"Question","name":"Есть ли реквизит?","acceptedAnswer":{"@type":"Answer","text":"Да: кресла, журнальные столики, передвижные зеркала, камин, цветы, коврики, колонка, свет, крюки для йоги"}},
-  {"@type":"Question","name":"Где находимся?","acceptedAnswer":{"@type":"Answer","text":"Байкальская, 19А, 5 этаж, вход с торца слева (рядом находится ТЦ «Карамель»). Есть парковка."}},
-  {"@type":"Question","name":"Как забронировать?","acceptedAnswer":{"@type":"Answer","text":"Через онлайн сервис Dikidi - видны свободные слоты."}},
-  {"@type":"Question","name":"Со своей едой?","acceptedAnswer":{"@type":"Answer","text":"Да, аккуратно: без сильных запахов/окраски. Свечи/конфетти - по согласованию."}},
-  {"@type":"Question","name":"Сколько людей войдет?","acceptedAnswer":{"@type":"Answer","text":"42 м²: съёмки до 10, занятия комфортно до 10-12 человек."}},
-  {"@type":"Question","name":"Продлить на месте?","acceptedAnswer":{"@type":"Answer","text":"Если есть окно - да, оплата по факту."}},
-  {"@type":"Question","name":"Музыка?","acceptedAnswer":{"@type":"Answer","text":"Bluetooth-колонка, подключение с телефона."}},
-  {"@type":"Question","name":"Обувь/покрытие?","acceptedAnswer":{"@type":"Answer","text":"Сменка/носки; качественный ламинат."}},
-  {"@type":"Question","name":"Дети/питомцы?","acceptedAnswer":{"@type":"Answer","text":"По согласованию."}}
- ]
-}
-</script>
+  <script type="application/ld+json">
+  {
+   "@context":"https://schema.org",
+   "@type":"BreadcrumbList",
+   "itemListElement":[
+    {"@type":"ListItem","position":1,"name":"Главная","item":"https://suncitystudio.ru/"},
+    {"@type":"ListItem","position":2,"name":"Зал для танцев","item":"https://suncitystudio.ru/tancy-zal-irkutsk/"}
+   ]
+  }
+  </script>
 
 
 
@@ -333,5 +329,6 @@ serviceModal.addEventListener('click', e => {
   if (!e.target.closest('img') && !e.target.closest('.service-prev') && !e.target.closest('.service-next') && !e.target.closest('.service-pagination')) closeService();
 });
 </script>
+<script>lucide.createIcons();</script>
 </body>
 </html>

--- a/yoga-zal-irkutsk/index.html
+++ b/yoga-zal-irkutsk/index.html
@@ -233,34 +233,31 @@
   </details>
 </div>
 
-<script type="application/ld+json">
-{
- "@context":"https://schema.org",
- "@type":"BreadcrumbList",
- "itemListElement":[
-  {"@type":"ListItem","position":1,"name":"Главная","item":"https://suncitystudio.ru/"},
-  {"@type":"ListItem","position":2,"name":"Зал для йоги","item":"https://suncitystudio.ru/yoga-zal-irkutsk/"}
- ]
-}
-</script>
-<script type="application/ld+json">
-{
- "@context":"https://schema.org",
- "@type":"FAQPage",
- "mainEntity":[
-  {"@type":"Question","name":"Перенести/отменить бронь?","acceptedAnswer":{"@type":"Answer","text":"Бесплатно ≥24 ч. <24 ч - по согласованию, перенос не гарантируется."}},
-  {"@type":"Question","name":"Есть ли реквизит?","acceptedAnswer":{"@type":"Answer","text":"Да: кресла, журнальные столики, передвижные зеркала, камин, цветы, коврики, колонка, свет, крюки для йоги"}},
-  {"@type":"Question","name":"Где находимся?","acceptedAnswer":{"@type":"Answer","text":"Байкальская, 19А, 5 этаж, вход с торца слева (рядом находится ТЦ «Карамель»). Есть парковка."}},
-  {"@type":"Question","name":"Как забронировать?","acceptedAnswer":{"@type":"Answer","text":"Через онлайн сервис Dikidi - видны свободные слоты."}},
-  {"@type":"Question","name":"Со своей едой?","acceptedAnswer":{"@type":"Answer","text":"Да, аккуратно: без сильных запахов/окраски. Свечи/конфетти - по согласованию."}},
-  {"@type":"Question","name":"Сколько людей войдет?","acceptedAnswer":{"@type":"Answer","text":"42 м²: съёмки до 10, занятия комфортно до 10-12 человек."}},
-  {"@type":"Question","name":"Продлить на месте?","acceptedAnswer":{"@type":"Answer","text":"Если есть окно - да, оплата по факту."}},
-  {"@type":"Question","name":"Музыка?","acceptedAnswer":{"@type":"Answer","text":"Bluetooth-колонка, подключение с телефона."}},
-  {"@type":"Question","name":"Обувь/покрытие?","acceptedAnswer":{"@type":"Answer","text":"Сменка/носки; качественный ламинат."}},
-  {"@type":"Question","name":"Дети/питомцы?","acceptedAnswer":{"@type":"Answer","text":"По согласованию."}}
- ]
-}
-</script>
+  <h2 class="text-2xl font-semibold mb-4">Читайте также</h2>
+  <ul class="list-disc list-inside mb-8">
+    <li><a href="/suncitystudio.ru/" class="text-orange-500 hover:underline">Главная</a></li>
+    <li><a href="/suncitystudio.ru/arenda-zala-irkutsk/" class="text-orange-500 hover:underline">Аренда зала</a></li>
+    <li><a href="/suncitystudio.ru/fotостudiya-irkutsk/" class="text-orange-500 hover:underline">Фотостудия</a></li>
+    <li><a href="/suncitystudio.ru/gender-party-irkutsk/" class="text-orange-500 hover:underline">Гендер-пати</a></li>
+    <li><a href="/suncitystudio.ru/yoga-zal-irkutsk/" class="text-orange-500 hover:underline">Йога</a></li>
+    <li><a href="/suncitystudio.ru/tancy-zal-irkutsk/" class="text-orange-500 hover:underline">Танцы</a></li>
+    <li><a href="/suncitystudio.ru/fly-yoga-irkutsk/" class="text-orange-500 hover:underline">Fly-йога</a></li>
+    <li><a href="/suncitystudio.ru/meropriyatiya-irkutsk/" class="text-orange-500 hover:underline">Мероприятия</a></li>
+    <li><a href="/suncitystudio.ru/ceny/" class="text-orange-500 hover:underline">Цены</a></li>
+    <li><a href="/suncitystudio.ru/pravila/" class="text-orange-500 hover:underline">Правила</a></li>
+    <li><a href="/suncitystudio.ru/kontakty/" class="text-orange-500 hover:underline">Контакты</a></li>
+  </ul>
+
+  <script type="application/ld+json">
+  {
+   "@context":"https://schema.org",
+   "@type":"BreadcrumbList",
+   "itemListElement":[
+    {"@type":"ListItem","position":1,"name":"Главная","item":"https://suncitystudio.ru/"},
+    {"@type":"ListItem","position":2,"name":"Зал для йоги","item":"https://suncitystudio.ru/yoga-zal-irkutsk/"}
+   ]
+  }
+  </script>
 
 
 
@@ -331,5 +328,6 @@ serviceModal.addEventListener('click', e => {
   if (!e.target.closest('img') && !e.target.closest('.service-prev') && !e.target.closest('.service-next') && !e.target.closest('.service-pagination')) closeService();
 });
 </script>
+<script>lucide.createIcons();</script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- ensure lucide icons render on subpages
- remove duplicate FAQ schema and add "Read more" section across pages

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a742bc8f20832c8a450816659905f8