### PR TITLE
Add viewport meta tag to subpages for mobile support

### DIFF
--- a/arenda-zala-irkutsk/index.html
+++ b/arenda-zala-irkutsk/index.html
@@ -2,6 +2,7 @@
 <html lang="ru">
 <head>
 <meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
 <title>Аренда зала почасово в Иркутске - SUNCITY</title>
 <meta name="description" content="Зал с зеркалами, светом и реквизитом. Удобно для тренировок, йоги и мероприятий. Бронь онлайн." />
 <link rel="canonical" href="https://suncitystudio.ru/arenda-zala-irkutsk/" />

--- a/ceny/index.html
+++ b/ceny/index.html
@@ -2,6 +2,7 @@
 <html lang="ru">
 <head>
 <meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
 <title>Цены на аренду зала и фотостудии в Иркутске - SUNCITY</title>
 <meta name="description" content="Актуальные почасовые тарифы и пакеты: утро/вечер, съёмки, йога, мероприятия. Скидки при длительной аренде." />
 <link rel="canonical" href="https://suncitystudio.ru/ceny/" />

--- a/fly-yoga-irkutsk/index.html
+++ b/fly-yoga-irkutsk/index.html
@@ -2,6 +2,7 @@
 <html lang="ru">
 <head>
 <meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
 <title>Флай-йога (аэро-йога) в Иркутске - аренда зала с гамаками</title>
 <meta name="description" content="Зал, подготовленный для флай-йоги: точки крепления, высота потолка, безопасность. Почасовая аренда." />
 <link rel="canonical" href="https://suncitystudio.ru/fly-yoga-irkutsk/" />

--- a/fotostudiya-irkutsk/index.html
+++ b/fotostudiya-irkutsk/index.html
@@ -2,6 +2,7 @@
 <html lang="ru">
 <head>
 <meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
 <title>Почасовая фотостудия в Иркутске - естественный свет | SUNCITY</title>
 <meta name="description" content="Фотостудия с естественным светом, фонами и реквизитом. Удобная почасовая аренда. Онлайн-бронирование." />
 <link rel="canonical" href="https://suncitystudio.ru/fotostudiya-irkutsk/" />

--- a/gender-party-irkutsk/index.html
+++ b/gender-party-irkutsk/index.html
@@ -2,6 +2,7 @@
 <html lang="ru">
 <head>
 <meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
 <title>Гендер-пати в Иркутске - аренда зала и оформление | SUNCITY</title>
 <meta name="description" content="Инста-локация, реквизит и помощь с оформлением. Удобная почасовая аренда для gender reveal." />
 <link rel="canonical" href="https://suncitystudio.ru/gender-party-irkutsk/" />

--- a/kontakty/index.html
+++ b/kontakty/index.html
@@ -2,6 +2,7 @@
 <html lang="ru">
 <head>
 <meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
 <title>Контакты SUNCITY - аренда зала в Иркутске</title>
 <meta name="description" content="Адрес: Иркутск, ул. Байкальская, 19А. Тел.: +7 902 510-12-06. Как добраться, парковка, мессенджеры." />
 <link rel="canonical" href="https://suncitystudio.ru/kontakty/" />

--- a/meropriyatiya-irkutsk/index.html
+++ b/meropriyatiya-irkutsk/index.html
@@ -2,6 +2,7 @@
 <html lang="ru">
 <head>
 <meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
 <title>Зал для мероприятий, мастер-классов и встреч - Иркутск | SUNCITY</title>
 <meta name="description" content="Проведение камерных мероприятий, воркшопов и встреч. Проектор по запросу, зона кофе-брейка." />
 <link rel="canonical" href="https://suncitystudio.ru/meropriyatiya-irkutsk/" />

--- a/pravila/index.html
+++ b/pravila/index.html
@@ -2,6 +2,7 @@
 <html lang="ru">
 <head>
 <meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
 <title>Правила и условия аренды - SUNCITY Иркутск</title>
 <meta name="description" content="Правила использования зала, политика отмены и переноса, время тихих и шумных активностей." />
 <link rel="canonical" href="https://suncitystudio.ru/pravila/" />

--- a/tancy-zal-irkutsk/index.html
+++ b/tancy-zal-irkutsk/index.html
@@ -2,6 +2,7 @@
 <html lang="ru">
 <head>
 <meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
 <title>Зал для танцев в аренду, Иркутск - зеркала, музыка | SUNCITY</title>
 <meta name="description" content="Аренда танцевального зала почасово: зеркальная стена, покрытие для танцев, акустика. Бронирование онлайн." />
 <link rel="canonical" href="https://suncitystudio.ru/tancy-zal-irkutsk/" />

--- a/yoga-zal-irkutsk/index.html
+++ b/yoga-zal-irkutsk/index.html
@@ -2,6 +2,7 @@
 <html lang="ru">
 <head>
 <meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
 <title>Зал для йоги в Иркутске - аренда почасово | SUNCITY</title>
 <meta name="description" content="Тихий зал для йоги и практик: коврики, блоки, вентиляция. Утренние и вечерние слоты. Бронируйте онлайн." />
 <link rel="canonical" href="https://suncitystudio.ru/yoga-zal-irkutsk/" />


### PR DESCRIPTION
## Summary
- add viewport meta tag to all secondary pages for proper mobile scaling

## Testing
- `npx -y htmlhint arenda-zala-irkutsk/index.html ceny/index.html fly-yoga-irkutsk/index.html fotostudiya-irkutsk/index.html gender-party-irkutsk/index.html kontakty/index.html meropriyatiya-irkutsk/index.html pravila/index.html tancy-zal-irkutsk/index.html yoga-zal-irkutsk/index.html`

------
https://chatgpt.com/codex/tasks/task_e_68a76cca4644832ca7cab8ed09fb6f1e