### PR TITLE
Correct fotostudiya link on yoga and ceny pages

### DIFF
--- a/ceny/index.html
+++ b/ceny/index.html
@@ -237,7 +237,7 @@
 <ul class="list-disc list-inside mb-8">
   <li><a href="/suncitystudio.ru/" class="text-orange-500 hover:underline">Главная</a></li>
   <li><a href="/suncitystudio.ru/arenda-zala-irkutsk/" class="text-orange-500 hover:underline">Аренда зала</a></li>
-  <li><a href="/suncitystudio.ru/fotостudiya-irkutsk/" class="text-orange-500 hover:underline">Фотостудия</a></li>
+  <li><a href="/suncitystudio.ru/fotostudiya-irkutsk/" class="text-orange-500 hover:underline">Фотостудия</a></li>
   <li><a href="/suncitystudio.ru/gender-party-irkutsk/" class="text-orange-500 hover:underline">Гендер-пати</a></li>
   <li><a href="/suncitystudio.ru/yoga-zal-irkutsk/" class="text-orange-500 hover:underline">Йога</a></li>
   <li><a href="/suncitystudio.ru/tancy-zal-irkutsk/" class="text-orange-500 hover:underline">Танцы</a></li>

--- a/yoga-zal-irkutsk/index.html
+++ b/yoga-zal-irkutsk/index.html
@@ -240,7 +240,7 @@
   <ul class="list-disc list-inside mb-8">
     <li><a href="/suncitystudio.ru/" class="text-orange-500 hover:underline">Главная</a></li>
     <li><a href="/suncitystudio.ru/arenda-zala-irkutsk/" class="text-orange-500 hover:underline">Аренда зала</a></li>
-    <li><a href="/suncitystudio.ru/fotостudiya-irkutsk/" class="text-orange-500 hover:underline">Фотостудия</a></li>
+    <li><a href="/suncitystudio.ru/fotostudiya-irkutsk/" class="text-orange-500 hover:underline">Фотостудия</a></li>
     <li><a href="/suncitystudio.ru/gender-party-irkutsk/" class="text-orange-500 hover:underline">Гендер-пати</a></li>
     <li><a href="/suncitystudio.ru/yoga-zal-irkutsk/" class="text-orange-500 hover:underline">Йога</a></li>
     <li><a href="/suncitystudio.ru/tancy-zal-irkutsk/" class="text-orange-500 hover:underline">Танцы</a></li>


### PR DESCRIPTION
## Summary
- fix mis-typed fotostudiya link containing Cyrillic characters
- verify no other URLs contain Cyrillic characters

## Testing
- `npm test` *(fails: enoent package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a773322b34832c962d026f97e18b26