### PR TITLE
Use relative image paths for portability

### DIFF
--- a/arenda-zala-irkutsk/index.html
+++ b/arenda-zala-irkutsk/index.html
@@ -13,8 +13,8 @@
 <meta name="twitter:title" content="Аренда зала почасово" />
 <meta name="twitter:description" content="Зеркала, естественный свет и реквизит в центре Иркутска" />
 <meta name="twitter:image" content="https://suncitystudio.ru/img/og-image.jpg" />
-<link rel="icon" href="/suncitystudio.ru/img/suncity-sun-camera.svg" type="image/svg+xml" />
-<link rel="icon" href="/suncitystudio.ru/img/suncity-sun-camera.ico" type="image/x-icon" />
+<link rel="icon" href="../img/suncity-sun-camera.svg" type="image/svg+xml" />
+<link rel="icon" href="../img/suncity-sun-camera.ico" type="image/x-icon" />
 <script src="https://cdn.tailwindcss.com"></script>
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/swiper@9/swiper-bundle.min.css" />
 <script src="https://unpkg.com/lucide@latest"></script>
@@ -51,7 +51,7 @@
 <body class="bg-white text-gray-800 font-sans">
 <header class="border-b bg-white">
   <nav class="max-w-screen-md mx-auto flex justify-between items-center p-4">
-    <a href="/suncitystudio.ru/" class="font-semibold flex items-center text-xl"><img src="/suncitystudio.ru/img/suncity-sun-camera.svg" alt="" class="w-8 h-8 mr-2" />SUNCITY</a>
+    <a href="/suncitystudio.ru/" class="font-semibold flex items-center text-xl"><img src="../img/suncity-sun-camera.svg" alt="" class="w-8 h-8 mr-2" />SUNCITY</a>
     <div id="nav-menu" class="hidden md:flex space-x-4">
       <a href="/suncitystudio.ru/#services" class="hover:text-orange-500">Услуги</a>
       <a href="/suncitystudio.ru/ceny/" class="hover:text-orange-500">Цены</a>
@@ -88,9 +88,9 @@
 <p class="mb-4">Выберите свободный слот в нашем календаре и подтвердите бронь онлайн. Оплата доступна по переводу или по счёту для юрлиц. Если планы изменились, перенести время можно без штрафа за 24 часа до начала аренды. Мы предоставим дополнительный реквизит: коврики для йоги, стулья, проектор или чайную зону.</p>
 <h2 class="text-2xl font-semibold mb-2">Галерея</h2>
 <div class="grid grid-cols-3 gap-2 mb-6">
-  <img src="/suncitystudio.ru/img/f1.webp" alt="Зал SUNCITY - фотосъёмка" loading="lazy" data-service="all" class="w-full aspect-[4/5] object-cover rounded cursor-pointer service-image" />
-  <img src="/suncitystudio.ru/img/m1.webp" alt="Зал SUNCITY - мероприятие" loading="lazy" data-service="all" class="w-full aspect-[4/5] object-cover rounded cursor-pointer service-image" />
-  <img src="/suncitystudio.ru/img/i1.webp" alt="Зал SUNCITY - йога" loading="lazy" data-service="all" class="w-full aspect-[4/5] object-cover rounded cursor-pointer service-image" />
+  <img src="../img/f1.webp" alt="Зал SUNCITY - фотосъёмка" loading="lazy" data-service="all" class="w-full aspect-[4/5] object-cover rounded cursor-pointer service-image" />
+  <img src="../img/m1.webp" alt="Зал SUNCITY - мероприятие" loading="lazy" data-service="all" class="w-full aspect-[4/5] object-cover rounded cursor-pointer service-image" />
+  <img src="../img/i1.webp" alt="Зал SUNCITY - йога" loading="lazy" data-service="all" class="w-full aspect-[4/5] object-cover rounded cursor-pointer service-image" />
 </div>
 <div class="mb-8 text-center">
   <a href="#"  class="booking-button inline-block bg-orange-500 text-white px-6 py-3 rounded-full">Забронировать</a>
@@ -310,7 +310,7 @@
     </div>
   </div>
 <footer class="mt-12 border-t pt-4 text-center text-sm text-gray-500">
-  <p class="flex items-center justify-center">&copy; 2024 <img src="/suncitystudio.ru/img/suncity-sun-camera.svg" alt="" class="w-6 h-6 mx-2" />SUNCITY, Иркутск</p>
+  <p class="flex items-center justify-center">&copy; 2024 <img src="../img/suncity-sun-camera.svg" alt="" class="w-6 h-6 mx-2" />SUNCITY, Иркутск</p>
   <nav class="mt-2 flex justify-center space-x-4">
     <a href="/suncitystudio.ru/pravila/" class="hover:text-orange-500">Правила</a>
     <a href="/suncitystudio.ru/kontakty/" class="hover:text-orange-500">Контакты</a>
@@ -322,7 +322,7 @@ const menuToggle = document.getElementById('menu-toggle');
 const mobileMenu = document.getElementById('mobile-menu');
 menuToggle.addEventListener('click', () => mobileMenu.classList.toggle('hidden'));
 
-const base = '/suncitystudio.ru/img/';
+const base = '../img/';
 const serviceGalleries = {
   photo: Array.from({ length: 34 }, (_, i) => `${base}f${i + 1}.webp`),
   yoga: Array.from({ length: 3 }, (_, i) => `${base}i${i + 1}.webp`),

--- a/ceny/index.html
+++ b/ceny/index.html
@@ -13,8 +13,8 @@
 <meta name="twitter:title" content="Цены на аренду" />
 <meta name="twitter:description" content="Актуальные почасовые тарифы SUNCITY" />
 <meta name="twitter:image" content="https://suncitystudio.ru/img/og-image.jpg" />
-<link rel="icon" href="/suncitystudio.ru/img/suncity-sun-camera.svg" type="image/svg+xml" />
-<link rel="icon" href="/suncitystudio.ru/img/suncity-sun-camera.ico" type="image/x-icon" />
+<link rel="icon" href="../img/suncity-sun-camera.svg" type="image/svg+xml" />
+<link rel="icon" href="../img/suncity-sun-camera.ico" type="image/x-icon" />
 <script src="https://cdn.tailwindcss.com"></script>
 <script src="https://unpkg.com/lucide@latest"></script>
 <script type="application/ld+json">
@@ -50,7 +50,7 @@
 <body class="bg-white text-gray-800 font-sans">
 <header class="border-b bg-white">
   <nav class="max-w-screen-md mx-auto flex justify-between items-center p-4">
-    <a href="/suncitystudio.ru/" class="font-semibold flex items-center text-xl"><img src="/suncitystudio.ru/img/suncity-sun-camera.svg" alt="" class="w-8 h-8 mr-2" />SUNCITY</a>
+    <a href="/suncitystudio.ru/" class="font-semibold flex items-center text-xl"><img src="../img/suncity-sun-camera.svg" alt="" class="w-8 h-8 mr-2" />SUNCITY</a>
     <div id="nav-menu" class="hidden md:flex space-x-4">
       <a href="/suncitystudio.ru/#services" class="hover:text-orange-500">Услуги</a>
       <a href="/suncitystudio.ru/ceny/" class="hover:text-orange-500">Цены</a>
@@ -286,7 +286,7 @@
 
 
 <footer class="mt-12 border-t pt-4 text-center text-sm text-gray-500">
-  <p class="flex items-center justify-center">&copy; 2024 <img src="/suncitystudio.ru/img/suncity-sun-camera.svg" alt="" class="w-6 h-6 mx-2" />SUNCITY, Иркутск</p>
+  <p class="flex items-center justify-center">&copy; 2024 <img src="../img/suncity-sun-camera.svg" alt="" class="w-6 h-6 mx-2" />SUNCITY, Иркутск</p>
   <nav class="mt-2 flex justify-center space-x-4">
     <a href="/suncitystudio.ru/pravila/" class="hover:text-orange-500">Правила</a>
     <a href="/suncitystudio.ru/kontakty/" class="hover:text-orange-500">Контакты</a>

--- a/fly-yoga-irkutsk/index.html
+++ b/fly-yoga-irkutsk/index.html
@@ -13,8 +13,8 @@
 <meta name="twitter:title" content="Флай-йога в Иркутске" />
 <meta name="twitter:description" content="Аренда зала с гамаками для аэро-йоги" />
 <meta name="twitter:image" content="https://suncitystudio.ru/img/og-image.jpg" />
-<link rel="icon" href="/suncitystudio.ru/img/suncity-sun-camera.svg" type="image/svg+xml" />
-<link rel="icon" href="/suncitystudio.ru/img/suncity-sun-camera.ico" type="image/x-icon" />
+<link rel="icon" href="../img/suncity-sun-camera.svg" type="image/svg+xml" />
+<link rel="icon" href="../img/suncity-sun-camera.ico" type="image/x-icon" />
 <script src="https://cdn.tailwindcss.com"></script>
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/swiper@9/swiper-bundle.min.css" />
 <script src="https://unpkg.com/lucide@latest"></script>
@@ -51,7 +51,7 @@
 <body class="bg-white text-gray-800 font-sans">
 <header class="border-b bg-white">
   <nav class="max-w-screen-md mx-auto flex justify-between items-center p-4">
-    <a href="/suncitystudio.ru/" class="font-semibold flex items-center text-xl"><img src="/suncitystudio.ru/img/suncity-sun-camera.svg" alt="" class="w-8 h-8 mr-2" />SUNCITY</a>
+    <a href="/suncitystudio.ru/" class="font-semibold flex items-center text-xl"><img src="../img/suncity-sun-camera.svg" alt="" class="w-8 h-8 mr-2" />SUNCITY</a>
     <div id="nav-menu" class="hidden md:flex space-x-4">
       <a href="/suncitystudio.ru/#services" class="hover:text-orange-500">Услуги</a>
       <a href="/suncitystudio.ru/ceny/" class="hover:text-orange-500">Цены</a>
@@ -84,9 +84,9 @@
 <p class="mb-4">Студия находится в центре города, рядом с остановками. Благодаря акустике и белым стенам можно проводить и фотосессии в гамаках. Почасовая аренда даёт свободу планировать занятия в удобное время.</p>
 <h2 class="text-2xl font-semibold mb-2">Галерея</h2>
 <div class="grid grid-cols-3 gap-2 mb-6">
-  <img src="/suncitystudio.ru/img/i1.webp" alt="Флай-йога гамак Иркутск" loading="lazy" data-service="yoga" class="w-full aspect-[4/5] object-cover rounded cursor-pointer service-image" />
-  <img src="/suncitystudio.ru/img/i2.webp" alt="Зал для аэро-йоги SUNCITY" loading="lazy" data-service="yoga" class="w-full aspect-[4/5] object-cover rounded cursor-pointer service-image" />
-  <img src="/suncitystudio.ru/img/i3.webp" alt="Аренда зала с гамаками Иркутск" loading="lazy" data-service="yoga" class="w-full aspect-[4/5] object-cover rounded cursor-pointer service-image" />
+  <img src="../img/i1.webp" alt="Флай-йога гамак Иркутск" loading="lazy" data-service="yoga" class="w-full aspect-[4/5] object-cover rounded cursor-pointer service-image" />
+  <img src="../img/i2.webp" alt="Зал для аэро-йоги SUNCITY" loading="lazy" data-service="yoga" class="w-full aspect-[4/5] object-cover rounded cursor-pointer service-image" />
+  <img src="../img/i3.webp" alt="Аренда зала с гамаками Иркутск" loading="lazy" data-service="yoga" class="w-full aspect-[4/5] object-cover rounded cursor-pointer service-image" />
 </div>
 <div class="mb-8 text-center">
   <a href="#"  class="booking-button inline-block bg-orange-500 text-white px-6 py-3 rounded-full">Забронировать</a>
@@ -309,7 +309,7 @@
     </div>
   </div>
 <footer class="mt-12 border-t pt-4 text-center text-sm text-gray-500">
-  <p class="flex items-center justify-center">&copy; 2024 <img src="/suncitystudio.ru/img/suncity-sun-camera.svg" alt="" class="w-6 h-6 mx-2" />SUNCITY, Иркутск</p>
+  <p class="flex items-center justify-center">&copy; 2024 <img src="../img/suncity-sun-camera.svg" alt="" class="w-6 h-6 mx-2" />SUNCITY, Иркутск</p>
   <nav class="mt-2 flex justify-center space-x-4">
     <a href="/suncitystudio.ru/pravila/" class="hover:text-orange-500">Правила</a>
     <a href="/suncitystudio.ru/kontakty/" class="hover:text-orange-500">Контакты</a>
@@ -321,7 +321,7 @@ const menuToggle = document.getElementById('menu-toggle');
 const mobileMenu = document.getElementById('mobile-menu');
 menuToggle.addEventListener('click', () => mobileMenu.classList.toggle('hidden'));
 
-const base = '/suncitystudio.ru/img/';
+const base = '../img/';
 const serviceGalleries = {
   photo: Array.from({ length: 34 }, (_, i) => `${base}f${i + 1}.webp`),
   yoga: Array.from({ length: 3 }, (_, i) => `${base}i${i + 1}.webp`),

--- a/fotostudiya-irkutsk/index.html
+++ b/fotostudiya-irkutsk/index.html
@@ -13,8 +13,8 @@
 <meta name="twitter:title" content="Фотостудия в Иркутске" />
 <meta name="twitter:description" content="Почасовая аренда с естественным светом" />
 <meta name="twitter:image" content="https://suncitystudio.ru/img/og-image.jpg" />
-<link rel="icon" href="/suncitystudio.ru/img/suncity-sun-camera.svg" type="image/svg+xml" />
-<link rel="icon" href="/suncitystudio.ru/img/suncity-sun-camera.ico" type="image/x-icon" />
+<link rel="icon" href="../img/suncity-sun-camera.svg" type="image/svg+xml" />
+<link rel="icon" href="../img/suncity-sun-camera.ico" type="image/x-icon" />
 <script src="https://cdn.tailwindcss.com"></script>
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/swiper@9/swiper-bundle.min.css" />
 <script src="https://unpkg.com/lucide@latest"></script>
@@ -51,7 +51,7 @@
 <body class="bg-white text-gray-800 font-sans">
 <header class="border-b bg-white">
   <nav class="max-w-screen-md mx-auto flex justify-between items-center p-4">
-    <a href="/suncitystudio.ru/" class="font-semibold flex items-center text-xl"><img src="/suncitystudio.ru/img/suncity-sun-camera.svg" alt="" class="w-8 h-8 mr-2" />SUNCITY</a>
+    <a href="/suncitystudio.ru/" class="font-semibold flex items-center text-xl"><img src="../img/suncity-sun-camera.svg" alt="" class="w-8 h-8 mr-2" />SUNCITY</a>
     <div id="nav-menu" class="hidden md:flex space-x-4">
       <a href="/suncitystudio.ru/#services" class="hover:text-orange-500">Услуги</a>
       <a href="/suncitystudio.ru/ceny/" class="hover:text-orange-500">Цены</a>
@@ -86,9 +86,9 @@
 <p class="mb-4">Вы можете выбрать свободное время в онлайн‑календаре или связаться с нами в мессенджерах. Оплата принимается переводом или по счёту. Для постоянных клиентов доступны скидки и возможность хранения реквизита в студии.</p>
 <h2 class="text-2xl font-semibold mb-2">Галерея</h2>
 <div class="grid grid-cols-3 gap-2 mb-6">
-  <img src="/suncitystudio.ru/img/f1.webp" alt="Фотостудия SUNCITY Иркутск" loading="lazy" data-service="photo" class="w-full aspect-[4/5] object-cover rounded cursor-pointer service-image" />
-  <img src="/suncitystudio.ru/img/f2.webp" alt="Естественный свет фотостудии SUNCITY" loading="lazy" data-service="photo" class="w-full aspect-[4/5] object-cover rounded cursor-pointer service-image" />
-  <img src="/suncitystudio.ru/img/f3.webp" alt="Реквизит фотостудии SUNCITY Иркутск" loading="lazy" data-service="photo" class="w-full aspect-[4/5] object-cover rounded cursor-pointer service-image" />
+  <img src="../img/f1.webp" alt="Фотостудия SUNCITY Иркутск" loading="lazy" data-service="photo" class="w-full aspect-[4/5] object-cover rounded cursor-pointer service-image" />
+  <img src="../img/f2.webp" alt="Естественный свет фотостудии SUNCITY" loading="lazy" data-service="photo" class="w-full aspect-[4/5] object-cover rounded cursor-pointer service-image" />
+  <img src="../img/f3.webp" alt="Реквизит фотостудии SUNCITY Иркутск" loading="lazy" data-service="photo" class="w-full aspect-[4/5] object-cover rounded cursor-pointer service-image" />
 </div>
 <div class="mb-8 text-center">
   <a href="#"  class="booking-button inline-block bg-orange-500 text-white px-6 py-3 rounded-full">Забронировать</a>
@@ -311,7 +311,7 @@
     </div>
   </div>
 <footer class="mt-12 border-t pt-4 text-center text-sm text-gray-500">
-  <p class="flex items-center justify-center">&copy; 2024 <img src="/suncitystudio.ru/img/suncity-sun-camera.svg" alt="" class="w-6 h-6 mx-2" />SUNCITY, Иркутск</p>
+  <p class="flex items-center justify-center">&copy; 2024 <img src="../img/suncity-sun-camera.svg" alt="" class="w-6 h-6 mx-2" />SUNCITY, Иркутск</p>
   <nav class="mt-2 flex justify-center space-x-4">
     <a href="/suncitystudio.ru/pravila/" class="hover:text-orange-500">Правила</a>
     <a href="/suncitystudio.ru/kontakty/" class="hover:text-orange-500">Контакты</a>
@@ -323,7 +323,7 @@ const menuToggle = document.getElementById('menu-toggle');
 const mobileMenu = document.getElementById('mobile-menu');
 menuToggle.addEventListener('click', () => mobileMenu.classList.toggle('hidden'));
 
-const base = '/suncitystudio.ru/img/';
+const base = '../img/';
 const serviceGalleries = {
   photo: Array.from({ length: 34 }, (_, i) => `${base}f${i + 1}.webp`),
   yoga: Array.from({ length: 3 }, (_, i) => `${base}i${i + 1}.webp`),

--- a/gender-party-irkutsk/index.html
+++ b/gender-party-irkutsk/index.html
@@ -13,8 +13,8 @@
 <meta name="twitter:title" content="Гендер-пати SUNCITY" />
 <meta name="twitter:description" content="Gender reveal в стильной студии" />
 <meta name="twitter:image" content="https://suncitystudio.ru/img/og-image.jpg" />
-<link rel="icon" href="/suncitystudio.ru/img/suncity-sun-camera.svg" type="image/svg+xml" />
-<link rel="icon" href="/suncitystudio.ru/img/suncity-sun-camera.ico" type="image/x-icon" />
+<link rel="icon" href="../img/suncity-sun-camera.svg" type="image/svg+xml" />
+<link rel="icon" href="../img/suncity-sun-camera.ico" type="image/x-icon" />
 <script src="https://cdn.tailwindcss.com"></script>
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/swiper@9/swiper-bundle.min.css" />
 <script src="https://unpkg.com/lucide@latest"></script>
@@ -51,7 +51,7 @@
 <body class="bg-white text-gray-800 font-sans">
 <header class="border-b bg-white">
   <nav class="max-w-screen-md mx-auto flex justify-between items-center p-4">
-    <a href="/suncitystudio.ru/" class="font-semibold flex items-center text-xl"><img src="/suncitystudio.ru/img/suncity-sun-camera.svg" alt="" class="w-8 h-8 mr-2" />SUNCITY</a>
+    <a href="/suncitystudio.ru/" class="font-semibold flex items-center text-xl"><img src="../img/suncity-sun-camera.svg" alt="" class="w-8 h-8 mr-2" />SUNCITY</a>
     <div id="nav-menu" class="hidden md:flex space-x-4">
       <a href="/suncitystudio.ru/#services" class="hover:text-orange-500">Услуги</a>
       <a href="/suncitystudio.ru/ceny/" class="hover:text-orange-500">Цены</a>
@@ -84,9 +84,9 @@
 <p class="mb-4">Центральное расположение облегчает приезд гостей, а парковка делает встречу беззаботной. Кнопка «Забронировать» позволяет заранее выбрать удобное время. Зал подходит и для других праздников: выпускных из роддома, дней рождений и семейных фотосессий.</p>
 <h2 class="text-2xl font-semibold mb-2">Галерея</h2>
 <div class="grid grid-cols-3 gap-2 mb-6">
-  <img src="/suncitystudio.ru/img/m1.webp" alt="Гендер-пати зал SUNCITY Иркутск" loading="lazy" data-service="event" class="w-full aspect-[4/5] object-cover rounded cursor-pointer service-image" />
-  <img src="/suncitystudio.ru/img/m2.webp" alt="Оформление гендер-пати SUNCITY" loading="lazy" data-service="event" class="w-full aspect-[4/5] object-cover rounded cursor-pointer service-image" />
-  <img src="/suncitystudio.ru/img/m3.webp" alt="Gender reveal Иркутск" loading="lazy" data-service="event" class="w-full aspect-[4/5] object-cover rounded cursor-pointer service-image" />
+  <img src="../img/m1.webp" alt="Гендер-пати зал SUNCITY Иркутск" loading="lazy" data-service="event" class="w-full aspect-[4/5] object-cover rounded cursor-pointer service-image" />
+  <img src="../img/m2.webp" alt="Оформление гендер-пати SUNCITY" loading="lazy" data-service="event" class="w-full aspect-[4/5] object-cover rounded cursor-pointer service-image" />
+  <img src="../img/m3.webp" alt="Gender reveal Иркутск" loading="lazy" data-service="event" class="w-full aspect-[4/5] object-cover rounded cursor-pointer service-image" />
 </div>
 <div class="mb-8 text-center">
   <a href="#"  class="booking-button inline-block bg-orange-500 text-white px-6 py-3 rounded-full">Забронировать</a>
@@ -311,7 +311,7 @@
     </div>
   </div>
 <footer class="mt-12 border-t pt-4 text-center text-sm text-gray-500">
-  <p class="flex items-center justify-center">&copy; 2024 <img src="/suncitystudio.ru/img/suncity-sun-camera.svg" alt="" class="w-6 h-6 mx-2" />SUNCITY, Иркутск</p>
+  <p class="flex items-center justify-center">&copy; 2024 <img src="../img/suncity-sun-camera.svg" alt="" class="w-6 h-6 mx-2" />SUNCITY, Иркутск</p>
   <nav class="mt-2 flex justify-center space-x-4">
     <a href="/suncitystudio.ru/pravila/" class="hover:text-orange-500">Правила</a>
     <a href="/suncitystudio.ru/kontakty/" class="hover:text-orange-500">Контакты</a>
@@ -323,7 +323,7 @@ const menuToggle = document.getElementById('menu-toggle');
 const mobileMenu = document.getElementById('mobile-menu');
 menuToggle.addEventListener('click', () => mobileMenu.classList.toggle('hidden'));
 
-const base = '/suncitystudio.ru/img/';
+const base = '../img/';
 const serviceGalleries = {
   photo: Array.from({ length: 34 }, (_, i) => `${base}f${i + 1}.webp`),
   yoga: Array.from({ length: 3 }, (_, i) => `${base}i${i + 1}.webp`),

--- a/index.html
+++ b/index.html
@@ -14,8 +14,8 @@
   <meta name="twitter:title" content="SUNCITY - аренда зала и фотостудии" />
   <meta name="twitter:description" content="Почасовая аренда зала и фотостудии SUNCITY в Иркутске" />
   <meta name="twitter:image" content="https://suncitystudio.ru/img/og-image.jpg" />
-  <link rel="icon" href="/suncitystudio.ru/img/suncity-sun-camera.svg" type="image/svg+xml" />
-  <link rel="icon" href="/suncitystudio.ru/img/suncity-sun-camera.ico" type="image/x-icon" />
+  <link rel="icon" href="img/suncity-sun-camera.svg" type="image/svg+xml" />
+  <link rel="icon" href="img/suncity-sun-camera.ico" type="image/x-icon" />
   <script src="https://cdn.tailwindcss.com"></script>
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/swiper@9/swiper-bundle.min.css" />
   <script src="https://unpkg.com/lucide@latest"></script>
@@ -91,7 +91,7 @@
   <!-- Sticky header -->
   <header class="fixed top-0 left-0 w-full bg-white/80 backdrop-blur z-50 border-b">
     <nav class="max-w-screen-md mx-auto flex justify-between items-center p-4 text-lg relative">
-      <a href="/suncitystudio.ru/" class="font-semibold flex items-center text-xl"><img src="/suncitystudio.ru/img/suncity-sun-camera.svg" alt="" class="w-8 h-8 mr-2" />SUNCITY</a>
+      <a href="/suncitystudio.ru/" class="font-semibold flex items-center text-xl"><img src="img/suncity-sun-camera.svg" alt="" class="w-8 h-8 mr-2" />SUNCITY</a>
       <div class="flex items-center">
         <div id="nav-menu" class="hidden absolute top-full right-0 bg-white border rounded shadow-md overflow-hidden flex flex-col text-sm divide-y divide-gray-200 md:static md:flex md:flex-row md:divide-y-0 md:space-x-4 md:overflow-visible md:border-0 md:shadow-none md:bg-transparent md:mt-0">
           <a href="#services" class="block px-4 py-2 hover:bg-gray-100 hover:text-orange-500 transition md:px-0 md:py-0 md:hover:bg-transparent">Услуги</a>
@@ -112,7 +112,7 @@
   </header>
 
   <!-- Hero -->
-  <section id="hero" class="relative pt-36 pb-20 text-center overflow-hidden bg-center bg-cover" style="background-image:url('/suncitystudio.ru/img/323-min.jpg');">
+  <section id="hero" class="relative pt-36 pb-20 text-center overflow-hidden bg-center bg-cover" style="background-image:url('img/323-min.jpg');">
     <div class="absolute inset-0 bg-white/70"></div>
     <div class="absolute top-0 left-0 right-0 h-24 bg-white"></div>
     <div class="relative z-10 max-w-screen-md mx-auto px-4">
@@ -199,9 +199,9 @@
     <div class="grid grid-cols-1 sm:grid-cols-2 gap-6">
       <div class="p-6 border rounded-xl shadow flex flex-col">
         <div class="mb-4 grid grid-cols-3 gap-2">
-          <img src="/suncitystudio.ru/img/f1.webp" alt="Фотосъёмка" data-service="photo" class="w-full aspect-[4/5] object-cover rounded cursor-pointer service-image" loading="lazy" />
-          <img src="/suncitystudio.ru/img/f2.webp" alt="Фотосъёмка" data-service="photo" class="w-full aspect-[4/5] object-cover rounded cursor-pointer service-image" loading="lazy" />
-          <img src="/suncitystudio.ru/img/f3.webp" alt="Фотосъёмка" data-service="photo" class="w-full aspect-[4/5] object-cover rounded cursor-pointer service-image" loading="lazy" />
+          <img src="img/f1.webp" alt="Фотосъёмка" data-service="photo" class="w-full aspect-[4/5] object-cover rounded cursor-pointer service-image" loading="lazy" />
+          <img src="img/f2.webp" alt="Фотосъёмка" data-service="photo" class="w-full aspect-[4/5] object-cover rounded cursor-pointer service-image" loading="lazy" />
+          <img src="img/f3.webp" alt="Фотосъёмка" data-service="photo" class="w-full aspect-[4/5] object-cover rounded cursor-pointer service-image" loading="lazy" />
         </div>
         <h3 class="text-xl font-semibold mb-2"><a href="/suncitystudio.ru/fotostudiya-irkutsk/" class="hover:underline">Фотосъёмка</a></h3>
         <p class="text-sm text-gray-500 mb-4">Профессиональные кадры в светлом зале</p>
@@ -209,9 +209,9 @@
       </div>
       <div class="p-6 border rounded-xl shadow flex flex-col">
         <div class="mb-4 grid grid-cols-3 gap-2">
-          <img src="/suncitystudio.ru/img/i1.webp" alt="Йога" data-service="yoga" class="w-full aspect-[4/5] object-cover rounded cursor-pointer service-image" loading="lazy" />
-          <img src="/suncitystudio.ru/img/i2.webp" alt="Йога" data-service="yoga" class="w-full aspect-[4/5] object-cover rounded cursor-pointer service-image" loading="lazy" />
-          <img src="/suncitystudio.ru/img/i3.webp" alt="Йога" data-service="yoga" class="w-full aspect-[4/5] object-cover rounded cursor-pointer service-image" loading="lazy" />
+          <img src="img/i1.webp" alt="Йога" data-service="yoga" class="w-full aspect-[4/5] object-cover rounded cursor-pointer service-image" loading="lazy" />
+          <img src="img/i2.webp" alt="Йога" data-service="yoga" class="w-full aspect-[4/5] object-cover rounded cursor-pointer service-image" loading="lazy" />
+          <img src="img/i3.webp" alt="Йога" data-service="yoga" class="w-full aspect-[4/5] object-cover rounded cursor-pointer service-image" loading="lazy" />
         </div>
         <h3 class="text-xl font-semibold mb-2"><a href="/suncitystudio.ru/yoga-zal-irkutsk/" class="hover:underline">Йога</a></h3>
         <p class="text-sm text-gray-500 mb-4">Спокойное пространство для практик</p>
@@ -219,9 +219,9 @@
       </div>
       <div class="p-6 border rounded-xl shadow flex flex-col">
         <div class="mb-4 grid grid-cols-3 gap-2">
-          <img src="/suncitystudio.ru/img/t1.webp" alt="Танцы" data-service="dance" class="w-full aspect-[4/5] object-cover rounded cursor-pointer service-image" loading="lazy" />
-          <img src="/suncitystudio.ru/img/t2.webp" alt="Танцы" data-service="dance" class="w-full aspect-[4/5] object-cover rounded cursor-pointer service-image" loading="lazy" />
-          <img src="/suncitystudio.ru/img/t3.webp" alt="Танцы" data-service="dance" class="w-full aspect-[4/5] object-cover rounded cursor-pointer service-image" loading="lazy" />
+          <img src="img/t1.webp" alt="Танцы" data-service="dance" class="w-full aspect-[4/5] object-cover rounded cursor-pointer service-image" loading="lazy" />
+          <img src="img/t2.webp" alt="Танцы" data-service="dance" class="w-full aspect-[4/5] object-cover rounded cursor-pointer service-image" loading="lazy" />
+          <img src="img/t3.webp" alt="Танцы" data-service="dance" class="w-full aspect-[4/5] object-cover rounded cursor-pointer service-image" loading="lazy" />
         </div>
         <h3 class="text-xl font-semibold mb-2"><a href="/suncitystudio.ru/tancy-zal-irkutsk/" class="hover:underline">Танцы</a></h3>
         <p class="text-sm text-gray-500 mb-4">Удобный зал для тренировок</p>
@@ -229,9 +229,9 @@
       </div>
       <div class="p-6 border rounded-xl shadow flex flex-col">
         <div class="mb-4 grid grid-cols-3 gap-2">
-          <img src="/suncitystudio.ru/img/m1.webp" alt="Мероприятия" data-service="event" class="w-full aspect-[4/5] object-cover rounded cursor-pointer service-image" loading="lazy" />
-          <img src="/suncitystudio.ru/img/m2.webp" alt="Мероприятия" data-service="event" class="w-full aspect-[4/5] object-cover rounded cursor-pointer service-image" loading="lazy" />
-          <img src="/suncitystudio.ru/img/m3.webp" alt="Мероприятия" data-service="event" class="w-full aspect-[4/5] object-cover rounded cursor-pointer service-image" loading="lazy" />
+          <img src="img/m1.webp" alt="Мероприятия" data-service="event" class="w-full aspect-[4/5] object-cover rounded cursor-pointer service-image" loading="lazy" />
+          <img src="img/m2.webp" alt="Мероприятия" data-service="event" class="w-full aspect-[4/5] object-cover rounded cursor-pointer service-image" loading="lazy" />
+          <img src="img/m3.webp" alt="Мероприятия" data-service="event" class="w-full aspect-[4/5] object-cover rounded cursor-pointer service-image" loading="lazy" />
         </div>
         <h3 class="text-xl font-semibold mb-2"><a href="/suncitystudio.ru/meropriyatiya-irkutsk/" class="hover:underline">Мероприятия</a></h3>
         <p class="text-sm text-gray-500 mb-4">Проведение мастер-классов и встреч</p>
@@ -287,9 +287,9 @@
   <section id="gallery" class="max-w-screen-md mx-auto px-4 py-12">
     <h2 class="text-2xl font-semibold text-center mb-8">Галерея</h2>
     <div class="grid grid-cols-3 gap-2" id="gallery-thumbs">
-      <img src="/suncitystudio.ru/img/f1.webp" alt="Галерея SUNCITY" data-service="all" class="w-full aspect-[4/5] object-cover rounded cursor-pointer service-image" loading="lazy" />
-      <img src="/suncitystudio.ru/img/i1.webp" alt="Галерея SUNCITY" data-service="all" class="w-full aspect-[4/5] object-cover rounded cursor-pointer service-image" loading="lazy" />
-      <img src="/suncitystudio.ru/img/t1.webp" alt="Галерея SUNCITY" data-service="all" class="w-full aspect-[4/5] object-cover rounded cursor-pointer service-image" loading="lazy" />
+      <img src="img/f1.webp" alt="Галерея SUNCITY" data-service="all" class="w-full aspect-[4/5] object-cover rounded cursor-pointer service-image" loading="lazy" />
+      <img src="img/i1.webp" alt="Галерея SUNCITY" data-service="all" class="w-full aspect-[4/5] object-cover rounded cursor-pointer service-image" loading="lazy" />
+      <img src="img/t1.webp" alt="Галерея SUNCITY" data-service="all" class="w-full aspect-[4/5] object-cover rounded cursor-pointer service-image" loading="lazy" />
     </div>
   </section>
 
@@ -445,7 +445,7 @@
   </section>
 
   <footer class="bg-white py-8 text-center text-sm text-gray-500">
-    <img src="/suncitystudio.ru/img/v1.webp" alt="Вход в студию" class="mx-auto mb-4 w-32 h-48 object-cover rounded" loading="lazy" />
+    <img src="img/v1.webp" alt="Вход в студию" class="mx-auto mb-4 w-32 h-48 object-cover rounded" loading="lazy" />
     <p>Вход в студию</p>
   </footer>
 
@@ -521,7 +521,7 @@
         if (e.target === bookingModal) closeBooking();
       });
 
-      const base = '/suncitystudio.ru/img/';
+      const base = 'img/';
       const serviceGalleries = {
         photo: Array.from({ length: 34 }, (_, i) => `${base}f${i + 1}.webp`),
         yoga: Array.from({ length: 3 }, (_, i) => `${base}i${i + 1}.webp`),
@@ -593,7 +593,7 @@
   </script>
 
   <footer class="mt-12 border-t pt-4 text-center text-sm text-gray-500">
-    <p class="flex items-center justify-center">&copy; 2024 <img src="/suncitystudio.ru/img/suncity-sun-camera.svg" alt="" class="w-6 h-6 mx-2" />SUNCITY, Иркутск</p>
+    <p class="flex items-center justify-center">&copy; 2024 <img src="img/suncity-sun-camera.svg" alt="" class="w-6 h-6 mx-2" />SUNCITY, Иркутск</p>
     <nav class="mt-2 flex justify-center space-x-4">
       <a href="/suncitystudio.ru/pravila/" class="hover:text-orange-500">Правила</a>
       <a href="/suncitystudio.ru/kontakty/" class="hover:text-orange-500">Контакты</a>

--- a/kontakty/index.html
+++ b/kontakty/index.html
@@ -13,15 +13,15 @@
 <meta name="twitter:title" content="Контакты SUNCITY" />
 <meta name="twitter:description" content="Как добраться до студии" />
 <meta name="twitter:image" content="https://suncitystudio.ru/img/og-image.jpg" />
-<link rel="icon" href="/suncitystudio.ru/img/suncity-sun-camera.svg" type="image/svg+xml" />
-<link rel="icon" href="/suncitystudio.ru/img/suncity-sun-camera.ico" type="image/x-icon" />
+<link rel="icon" href="../img/suncity-sun-camera.svg" type="image/svg+xml" />
+<link rel="icon" href="../img/suncity-sun-camera.ico" type="image/x-icon" />
 <script src="https://cdn.tailwindcss.com"></script>
 <script src="https://unpkg.com/lucide@latest"></script>
 </head>
 <body class="bg-white text-gray-800 font-sans">
 <header class="border-b bg-white">
   <nav class="max-w-screen-md mx-auto flex justify-between items-center p-4">
-    <a href="/suncitystudio.ru/" class="font-semibold flex items-center text-xl"><img src="/suncitystudio.ru/img/suncity-sun-camera.svg" alt="" class="w-8 h-8 mr-2" />SUNCITY</a>
+    <a href="/suncitystudio.ru/" class="font-semibold flex items-center text-xl"><img src="../img/suncity-sun-camera.svg" alt="" class="w-8 h-8 mr-2" />SUNCITY</a>
     <div id="nav-menu" class="hidden md:flex space-x-4">
       <a href="/suncitystudio.ru/#services" class="hover:text-orange-500">Услуги</a>
       <a href="/suncitystudio.ru/ceny/" class="hover:text-orange-500">Цены</a>
@@ -107,7 +107,7 @@
 
 
 <footer class="mt-12 border-t pt-4 text-center text-sm text-gray-500">
-  <p class="flex items-center justify-center">&copy; 2024 <img src="/suncitystudio.ru/img/suncity-sun-camera.svg" alt="" class="w-6 h-6 mx-2" />SUNCITY, Иркутск</p>
+  <p class="flex items-center justify-center">&copy; 2024 <img src="../img/suncity-sun-camera.svg" alt="" class="w-6 h-6 mx-2" />SUNCITY, Иркутск</p>
   <nav class="mt-2 flex justify-center space-x-4">
     <a href="/suncitystudio.ru/pravila/" class="hover:text-orange-500">Правила</a>
     <a href="/suncitystudio.ru/kontakty/" class="hover:text-orange-500">Контакты</a>

--- a/meropriyatiya-irkutsk/index.html
+++ b/meropriyatiya-irkutsk/index.html
@@ -13,8 +13,8 @@
 <meta name="twitter:title" content="Зал для мероприятий" />
 <meta name="twitter:description" content="Аренда зала для встреч и мастер-классов" />
 <meta name="twitter:image" content="https://suncitystudio.ru/img/og-image.jpg" />
-<link rel="icon" href="/suncitystudio.ru/img/suncity-sun-camera.svg" type="image/svg+xml" />
-<link rel="icon" href="/suncitystudio.ru/img/suncity-sun-camera.ico" type="image/x-icon" />
+<link rel="icon" href="../img/suncity-sun-camera.svg" type="image/svg+xml" />
+<link rel="icon" href="../img/suncity-sun-camera.ico" type="image/x-icon" />
 <script src="https://cdn.tailwindcss.com"></script>
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/swiper@9/swiper-bundle.min.css" />
 <script src="https://unpkg.com/lucide@latest"></script>
@@ -51,7 +51,7 @@
 <body class="bg-white text-gray-800 font-sans">
 <header class="border-b bg-white">
   <nav class="max-w-screen-md mx-auto flex justify-between items-center p-4">
-    <a href="/suncitystudio.ru/" class="font-semibold flex items-center text-xl"><img src="/suncitystudio.ru/img/suncity-sun-camera.svg" alt="" class="w-8 h-8 mr-2" />SUNCITY</a>
+    <a href="/suncitystudio.ru/" class="font-semibold flex items-center text-xl"><img src="../img/suncity-sun-camera.svg" alt="" class="w-8 h-8 mr-2" />SUNCITY</a>
     <div id="nav-menu" class="hidden md:flex space-x-4">
       <a href="/suncitystudio.ru/#services" class="hover:text-orange-500">Услуги</a>
       <a href="/suncitystudio.ru/ceny/" class="hover:text-orange-500">Цены</a>
@@ -84,9 +84,9 @@
 <p class="mb-4">Наше пространство выбирают организаторы тренингов, психологических групп, творческих встреч и праздников. Расположение в центре Иркутска удобно для гостей, а наличие парковки решает вопрос с автомобилями.</p>
 <h2 class="text-2xl font-semibold mb-2">Галерея</h2>
 <div class="grid grid-cols-3 gap-2 mb-6">
-  <img src="/suncitystudio.ru/img/m1.webp" alt="Зал для мероприятий SUNCITY Иркутск" loading="lazy" data-service="event" class="w-full aspect-[4/5] object-cover rounded cursor-pointer service-image" />
-  <img src="/suncitystudio.ru/img/m2.webp" alt="Мастер-класс в SUNCITY Иркутск" loading="lazy" data-service="event" class="w-full aspect-[4/5] object-cover rounded cursor-pointer service-image" />
-  <img src="/suncitystudio.ru/img/m3.webp" alt="Аренда зала для встречи Иркутск" loading="lazy" data-service="event" class="w-full aspect-[4/5] object-cover rounded cursor-pointer service-image" />
+  <img src="../img/m1.webp" alt="Зал для мероприятий SUNCITY Иркутск" loading="lazy" data-service="event" class="w-full aspect-[4/5] object-cover rounded cursor-pointer service-image" />
+  <img src="../img/m2.webp" alt="Мастер-класс в SUNCITY Иркутск" loading="lazy" data-service="event" class="w-full aspect-[4/5] object-cover rounded cursor-pointer service-image" />
+  <img src="../img/m3.webp" alt="Аренда зала для встречи Иркутск" loading="lazy" data-service="event" class="w-full aspect-[4/5] object-cover rounded cursor-pointer service-image" />
 </div>
 <div class="mb-8 text-center">
   <a href="#"  class="booking-button inline-block bg-orange-500 text-white px-6 py-3 rounded-full">Забронировать</a>
@@ -310,7 +310,7 @@
     </div>
   </div>
 <footer class="mt-12 border-t pt-4 text-center text-sm text-gray-500">
-  <p class="flex items-center justify-center">&copy; 2024 <img src="/suncitystudio.ru/img/suncity-sun-camera.svg" alt="" class="w-6 h-6 mx-2" />SUNCITY, Иркутск</p>
+  <p class="flex items-center justify-center">&copy; 2024 <img src="../img/suncity-sun-camera.svg" alt="" class="w-6 h-6 mx-2" />SUNCITY, Иркутск</p>
   <nav class="mt-2 flex justify-center space-x-4">
     <a href="/suncitystudio.ru/pravila/" class="hover:text-orange-500">Правила</a>
     <a href="/suncitystudio.ru/kontakty/" class="hover:text-orange-500">Контакты</a>
@@ -322,7 +322,7 @@ const menuToggle = document.getElementById('menu-toggle');
 const mobileMenu = document.getElementById('mobile-menu');
 menuToggle.addEventListener('click', () => mobileMenu.classList.toggle('hidden'));
 
-const base = '/suncitystudio.ru/img/';
+const base = '../img/';
 const serviceGalleries = {
   photo: Array.from({ length: 34 }, (_, i) => `${base}f${i + 1}.webp`),
   yoga: Array.from({ length: 3 }, (_, i) => `${base}i${i + 1}.webp`),

--- a/pravila/index.html
+++ b/pravila/index.html
@@ -13,8 +13,8 @@
 <meta name="twitter:title" content="Правила аренды SUNCITY" />
 <meta name="twitter:description" content="Условия использования зала и оборудования" />
 <meta name="twitter:image" content="https://suncitystudio.ru/img/og-image.jpg" />
-<link rel="icon" href="/suncitystudio.ru/img/suncity-sun-camera.svg" type="image/svg+xml" />
-<link rel="icon" href="/suncitystudio.ru/img/suncity-sun-camera.ico" type="image/x-icon" />
+<link rel="icon" href="../img/suncity-sun-camera.svg" type="image/svg+xml" />
+<link rel="icon" href="../img/suncity-sun-camera.ico" type="image/x-icon" />
 <script src="https://cdn.tailwindcss.com"></script>
 <script src="https://unpkg.com/lucide@latest"></script>
 <script type="application/ld+json">
@@ -51,7 +51,7 @@
 <body class="bg-white text-gray-800 font-sans">
 <header class="border-b bg-white">
   <nav class="max-w-screen-md mx-auto flex justify-between items-center p-4">
-    <a href="/suncitystudio.ru/" class="font-semibold flex items-center text-xl"><img src="/suncitystudio.ru/img/suncity-sun-camera.svg" alt="" class="w-8 h-8 mr-2" />SUNCITY</a>
+    <a href="/suncitystudio.ru/" class="font-semibold flex items-center text-xl"><img src="../img/suncity-sun-camera.svg" alt="" class="w-8 h-8 mr-2" />SUNCITY</a>
     <div id="nav-menu" class="hidden md:flex space-x-4">
       <a href="/suncitystudio.ru/#services" class="hover:text-orange-500">Услуги</a>
       <a href="/suncitystudio.ru/ceny/" class="hover:text-orange-500">Цены</a>
@@ -136,7 +136,7 @@
   </div>
 
 <footer class="mt-12 border-t pt-4 text-center text-sm text-gray-500">
-  <p class="flex items-center justify-center">&copy; 2024 <img src="/suncitystudio.ru/img/suncity-sun-camera.svg" alt="" class="w-6 h-6 mx-2" />SUNCITY, Иркутск</p>
+  <p class="flex items-center justify-center">&copy; 2024 <img src="../img/suncity-sun-camera.svg" alt="" class="w-6 h-6 mx-2" />SUNCITY, Иркутск</p>
   <nav class="mt-2 flex justify-center space-x-4">
     <a href="/suncitystudio.ru/pravila/" class="hover:text-orange-500">Правила</a>
     <a href="/suncitystudio.ru/kontakty/" class="hover:text-orange-500">Контакты</a>

--- a/tancy-zal-irkutsk/index.html
+++ b/tancy-zal-irkutsk/index.html
@@ -13,8 +13,8 @@
 <meta name="twitter:title" content="Зал для танцев" />
 <meta name="twitter:description" content="Почасовая аренда танцевального зала в Иркутске" />
 <meta name="twitter:image" content="https://suncitystudio.ru/img/og-image.jpg" />
-<link rel="icon" href="/suncitystudio.ru/img/suncity-sun-camera.svg" type="image/svg+xml" />
-<link rel="icon" href="/suncitystudio.ru/img/suncity-sun-camera.ico" type="image/x-icon" />
+<link rel="icon" href="../img/suncity-sun-camera.svg" type="image/svg+xml" />
+<link rel="icon" href="../img/suncity-sun-camera.ico" type="image/x-icon" />
 <script src="https://cdn.tailwindcss.com"></script>
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/swiper@9/swiper-bundle.min.css" />
 <script src="https://unpkg.com/lucide@latest"></script>
@@ -51,7 +51,7 @@
 <body class="bg-white text-gray-800 font-sans">
 <header class="border-b bg-white">
   <nav class="max-w-screen-md mx-auto flex justify-between items-center p-4">
-    <a href="/suncitystudio.ru/" class="font-semibold flex items-center text-xl"><img src="/suncitystudio.ru/img/suncity-sun-camera.svg" alt="" class="w-8 h-8 mr-2" />SUNCITY</a>
+    <a href="/suncitystudio.ru/" class="font-semibold flex items-center text-xl"><img src="../img/suncity-sun-camera.svg" alt="" class="w-8 h-8 mr-2" />SUNCITY</a>
     <div id="nav-menu" class="hidden md:flex space-x-4">
       <a href="/suncitystudio.ru/#services" class="hover:text-orange-500">Услуги</a>
       <a href="/suncitystudio.ru/ceny/" class="hover:text-orange-500">Цены</a>
@@ -84,9 +84,9 @@
 <p class="mb-4">SUNCITY расположен в центре Иркутска, рядом с остановками транспорта и парковкой. Мы поддерживаем чистоту и уделяем внимание климату: в зале свежо летом и тепло зимой. Зеркала без искажений помогают отрабатывать технику, а акустика позволяет слышать каждый ритм без посторонних шумов.</p>
 <h2 class="text-2xl font-semibold mb-2">Галерея</h2>
 <div class="grid grid-cols-3 gap-2 mb-6">
-  <img src="/suncitystudio.ru/img/t1.webp" alt="Танцевальный зал SUNCITY Иркутск" loading="lazy" data-service="dance" class="w-full aspect-[4/5] object-cover rounded cursor-pointer service-image" />
-  <img src="/suncitystudio.ru/img/t2.webp" alt="Зал с зеркалами для танцев Иркутск" loading="lazy" data-service="dance" class="w-full aspect-[4/5] object-cover rounded cursor-pointer service-image" />
-  <img src="/suncitystudio.ru/img/t3.webp" alt="Аренда зала для танцев Иркутск" loading="lazy" data-service="dance" class="w-full aspect-[4/5] object-cover rounded cursor-pointer service-image" />
+  <img src="../img/t1.webp" alt="Танцевальный зал SUNCITY Иркутск" loading="lazy" data-service="dance" class="w-full aspect-[4/5] object-cover rounded cursor-pointer service-image" />
+  <img src="../img/t2.webp" alt="Зал с зеркалами для танцев Иркутск" loading="lazy" data-service="dance" class="w-full aspect-[4/5] object-cover rounded cursor-pointer service-image" />
+  <img src="../img/t3.webp" alt="Аренда зала для танцев Иркутск" loading="lazy" data-service="dance" class="w-full aspect-[4/5] object-cover rounded cursor-pointer service-image" />
 </div>
 <div class="mb-8 text-center">
   <a href="#"  class="booking-button inline-block bg-orange-500 text-white px-6 py-3 rounded-full">Забронировать</a>
@@ -311,7 +311,7 @@
     </div>
   </div>
 <footer class="mt-12 border-t pt-4 text-center text-sm text-gray-500">
-  <p class="flex items-center justify-center">&copy; 2024 <img src="/suncitystudio.ru/img/suncity-sun-camera.svg" alt="" class="w-6 h-6 mx-2" />SUNCITY, Иркутск</p>
+  <p class="flex items-center justify-center">&copy; 2024 <img src="../img/suncity-sun-camera.svg" alt="" class="w-6 h-6 mx-2" />SUNCITY, Иркутск</p>
   <nav class="mt-2 flex justify-center space-x-4">
     <a href="/suncitystudio.ru/pravila/" class="hover:text-orange-500">Правила</a>
     <a href="/suncitystudio.ru/kontakty/" class="hover:text-orange-500">Контакты</a>
@@ -323,7 +323,7 @@ const menuToggle = document.getElementById('menu-toggle');
 const mobileMenu = document.getElementById('mobile-menu');
 menuToggle.addEventListener('click', () => mobileMenu.classList.toggle('hidden'));
 
-const base = '/suncitystudio.ru/img/';
+const base = '../img/';
 const serviceGalleries = {
   photo: Array.from({ length: 34 }, (_, i) => `${base}f${i + 1}.webp`),
   yoga: Array.from({ length: 3 }, (_, i) => `${base}i${i + 1}.webp`),

--- a/yoga-zal-irkutsk/index.html
+++ b/yoga-zal-irkutsk/index.html
@@ -13,8 +13,8 @@
 <meta name="twitter:title" content="Зал для йоги" />
 <meta name="twitter:description" content="Аренда зала для йоги в центре Иркутска" />
 <meta name="twitter:image" content="https://suncitystudio.ru/img/og-image.jpg" />
-<link rel="icon" href="/suncitystudio.ru/img/suncity-sun-camera.svg" type="image/svg+xml" />
-<link rel="icon" href="/suncitystudio.ru/img/suncity-sun-camera.ico" type="image/x-icon" />
+<link rel="icon" href="../img/suncity-sun-camera.svg" type="image/svg+xml" />
+<link rel="icon" href="../img/suncity-sun-camera.ico" type="image/x-icon" />
 <script src="https://cdn.tailwindcss.com"></script>
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/swiper@9/swiper-bundle.min.css" />
 <script src="https://unpkg.com/lucide@latest"></script>
@@ -51,7 +51,7 @@
 <body class="bg-white text-gray-800 font-sans">
 <header class="border-b bg-white">
   <nav class="max-w-screen-md mx-auto flex justify-between items-center p-4">
-    <a href="/suncitystudio.ru/" class="font-semibold flex items-center text-xl"><img src="/suncitystudio.ru/img/suncity-sun-camera.svg" alt="" class="w-8 h-8 mr-2" />SUNCITY</a>
+    <a href="/suncitystudio.ru/" class="font-semibold flex items-center text-xl"><img src="../img/suncity-sun-camera.svg" alt="" class="w-8 h-8 mr-2" />SUNCITY</a>
     <div id="nav-menu" class="hidden md:flex space-x-4">
       <a href="/suncitystudio.ru/#services" class="hover:text-orange-500">Услуги</a>
       <a href="/suncitystudio.ru/ceny/" class="hover:text-orange-500">Цены</a>
@@ -84,9 +84,9 @@
 <p class="mb-4">Пространство подходит для индивидуальных занятий, небольших групп, йога-ретритов, дыхательных практик и релаксационных мастер-классов. Инструкторы отмечают тишину и отсутствие посторонних шумов, а ученики - ощущение уюта и свободы.</p>
 <h2 class="text-2xl font-semibold mb-2">Галерея</h2>
 <div class="grid grid-cols-3 gap-2 mb-6">
-  <img src="/suncitystudio.ru/img/i1.webp" alt="Зал для йоги SUNCITY Иркутск" loading="lazy" data-service="yoga" class="w-full aspect-[4/5] object-cover rounded cursor-pointer service-image" />
-  <img src="/suncitystudio.ru/img/i2.webp" alt="Практика йоги в зале SUNCITY Иркутск" loading="lazy" data-service="yoga" class="w-full aspect-[4/5] object-cover rounded cursor-pointer service-image" />
-  <img src="/suncitystudio.ru/img/i3.webp" alt="Аренда зала для йоги в Иркутске" loading="lazy" data-service="yoga" class="w-full aspect-[4/5] object-cover rounded cursor-pointer service-image" />
+  <img src="../img/i1.webp" alt="Зал для йоги SUNCITY Иркутск" loading="lazy" data-service="yoga" class="w-full aspect-[4/5] object-cover rounded cursor-pointer service-image" />
+  <img src="../img/i2.webp" alt="Практика йоги в зале SUNCITY Иркутск" loading="lazy" data-service="yoga" class="w-full aspect-[4/5] object-cover rounded cursor-pointer service-image" />
+  <img src="../img/i3.webp" alt="Аренда зала для йоги в Иркутске" loading="lazy" data-service="yoga" class="w-full aspect-[4/5] object-cover rounded cursor-pointer service-image" />
 </div>
 <div class="mb-8 text-center">
   <a href="#"  class="booking-button inline-block bg-orange-500 text-white px-6 py-3 rounded-full">Забронировать</a>
@@ -300,7 +300,7 @@
     </div>
   </div>
 <footer class="mt-12 border-t pt-4 text-center text-sm text-gray-500">
-  <p class="flex items-center justify-center">&copy; 2024 <img src="/suncitystudio.ru/img/suncity-sun-camera.svg" alt="" class="w-6 h-6 mx-2" />SUNCITY, Иркутск</p>
+  <p class="flex items-center justify-center">&copy; 2024 <img src="../img/suncity-sun-camera.svg" alt="" class="w-6 h-6 mx-2" />SUNCITY, Иркутск</p>
   <nav class="mt-2 flex justify-center space-x-4">
     <a href="/suncitystudio.ru/pravila/" class="hover:text-orange-500">Правила</a>
     <a href="/suncitystudio.ru/kontakty/" class="hover:text-orange-500">Контакты</a>
@@ -312,7 +312,7 @@ const menuToggle = document.getElementById('menu-toggle');
 const mobileMenu = document.getElementById('mobile-menu');
 menuToggle.addEventListener('click', () => mobileMenu.classList.toggle('hidden'));
 
-const base = '/suncitystudio.ru/img/';
+const base = '../img/';
 const serviceGalleries = {
   photo: Array.from({ length: 34 }, (_, i) => `${base}f${i + 1}.webp`),
   yoga: Array.from({ length: 3 }, (_, i) => `${base}i${i + 1}.webp`),


### PR DESCRIPTION
## Summary
- replace `/suncitystudio.ru/img` URLs with relative `img` paths so images load on both the hosted site and in the repo
- update JavaScript galleries to use the new relative base paths

## Testing
- `npx prettier -c index.html fly-yoga-irkutsk/index.html arenda-zala-irkutsk/index.html pravila/index.html ceny/index.html meropriyatiya-irkutsk/index.html tancy-zal-irkutsk/index.html kontakty/index.html gender-party-irkutsk/index.html fotostudiya-irkutsk/index.html yoga-zal-irkutsk/index.html` *(fails: code style warnings)*
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a96774a390832cb8f36a57b72f17d0