### PR TITLE
Enable Yandex Metrika webvisor and auto goals

### DIFF
--- a/arenda-zala-irkutsk/index.html
+++ b/arenda-zala-irkutsk/index.html
@@ -47,6 +47,20 @@
   "sameAs":["https://vk.com/...","https://instagram.com/..."]
 }
 </script>
+    <!-- Yandex.Metrika counter -->
+    <script type="text/javascript">
+        (function(m,e,t,r,i,k,a){
+            m[i]=m[i]||function(){(m[i].a=m[i].a||[]).push(arguments)};
+            m[i].l=1*new Date();
+            for (var j = 0; j < document.scripts.length; j++) {if (document.scripts[j].src === r) { return; }}
+            k=e.createElement(t),a=e.getElementsByTagName(t)[0],k.async=1,k.src=r,a.parentNode.insertBefore(k,a)
+        })(window, document,'script','https://mc.yandex.ru/metrika/tag.js', 'ym');
+
+        ym(98270380, 'init', {webvisor:true, clickmap:true, accurateTrackBounce:true, trackLinks:true});
+    </script>
+    <noscript><div><img src="https://mc.yandex.ru/watch/98270380" style="position:absolute; left:-9999px;" alt="" /></div></noscript>
+    <!-- /Yandex.Metrika counter -->
+
 </head>
 <body class="bg-white text-gray-800 font-sans">
 <header class="border-b bg-white">
@@ -381,5 +395,14 @@ bookingModal.addEventListener('click', e => {
 
 </script>
 <script>lucide.createIcons();</script>
+<script>
+  document.querySelectorAll('.booking-button').forEach(btn => {
+    btn.addEventListener('click', () => ym(98270380, 'reachGoal', 'booking'));
+  });
+  document.querySelectorAll('a[href^="tel:"], a[href^="mailto:"], a[href*="wa.me"], a[href*="t.me"]').forEach(link => {
+    link.addEventListener('click', () => ym(98270380, 'reachGoal', 'contact'));
+  });
+</script>
+
 </body>
 </html>

--- a/ceny/index.html
+++ b/ceny/index.html
@@ -46,6 +46,20 @@
   "sameAs":["https://vk.com/...","https://instagram.com/..."]
 }
 </script>
+    <!-- Yandex.Metrika counter -->
+    <script type="text/javascript">
+        (function(m,e,t,r,i,k,a){
+            m[i]=m[i]||function(){(m[i].a=m[i].a||[]).push(arguments)};
+            m[i].l=1*new Date();
+            for (var j = 0; j < document.scripts.length; j++) {if (document.scripts[j].src === r) { return; }}
+            k=e.createElement(t),a=e.getElementsByTagName(t)[0],k.async=1,k.src=r,a.parentNode.insertBefore(k,a)
+        })(window, document,'script','https://mc.yandex.ru/metrika/tag.js', 'ym');
+
+        ym(98270380, 'init', {webvisor:true, clickmap:true, accurateTrackBounce:true, trackLinks:true});
+    </script>
+    <noscript><div><img src="https://mc.yandex.ru/watch/98270380" style="position:absolute; left:-9999px;" alt="" /></div></noscript>
+    <!-- /Yandex.Metrika counter -->
+
 </head>
 <body class="bg-white text-gray-800 font-sans">
 <header class="border-b bg-white">
@@ -330,5 +344,14 @@ document.head.appendChild(s);
 });
 </script>
 <script>lucide.createIcons();</script>
+<script>
+  document.querySelectorAll('.booking-button').forEach(btn => {
+    btn.addEventListener('click', () => ym(98270380, 'reachGoal', 'booking'));
+  });
+  document.querySelectorAll('a[href^="tel:"], a[href^="mailto:"], a[href*="wa.me"], a[href*="t.me"]').forEach(link => {
+    link.addEventListener('click', () => ym(98270380, 'reachGoal', 'contact'));
+  });
+</script>
+
 </body>
 </html>

--- a/fly-yoga-irkutsk/index.html
+++ b/fly-yoga-irkutsk/index.html
@@ -47,6 +47,20 @@
   "sameAs":["https://vk.com/...","https://instagram.com/..."]
 }
 </script>
+    <!-- Yandex.Metrika counter -->
+    <script type="text/javascript">
+        (function(m,e,t,r,i,k,a){
+            m[i]=m[i]||function(){(m[i].a=m[i].a||[]).push(arguments)};
+            m[i].l=1*new Date();
+            for (var j = 0; j < document.scripts.length; j++) {if (document.scripts[j].src === r) { return; }}
+            k=e.createElement(t),a=e.getElementsByTagName(t)[0],k.async=1,k.src=r,a.parentNode.insertBefore(k,a)
+        })(window, document,'script','https://mc.yandex.ru/metrika/tag.js', 'ym');
+
+        ym(98270380, 'init', {webvisor:true, clickmap:true, accurateTrackBounce:true, trackLinks:true});
+    </script>
+    <noscript><div><img src="https://mc.yandex.ru/watch/98270380" style="position:absolute; left:-9999px;" alt="" /></div></noscript>
+    <!-- /Yandex.Metrika counter -->
+
 </head>
 <body class="bg-white text-gray-800 font-sans">
 <header class="border-b bg-white">
@@ -380,5 +394,14 @@ bookingModal.addEventListener('click', e => {
 
 </script>
 <script>lucide.createIcons();</script>
+<script>
+  document.querySelectorAll('.booking-button').forEach(btn => {
+    btn.addEventListener('click', () => ym(98270380, 'reachGoal', 'booking'));
+  });
+  document.querySelectorAll('a[href^="tel:"], a[href^="mailto:"], a[href*="wa.me"], a[href*="t.me"]').forEach(link => {
+    link.addEventListener('click', () => ym(98270380, 'reachGoal', 'contact'));
+  });
+</script>
+
 </body>
 </html>

--- a/fotostudiya-irkutsk/index.html
+++ b/fotostudiya-irkutsk/index.html
@@ -47,6 +47,20 @@
   "sameAs":["https://vk.com/...","https://instagram.com/..."]
 }
 </script>
+    <!-- Yandex.Metrika counter -->
+    <script type="text/javascript">
+        (function(m,e,t,r,i,k,a){
+            m[i]=m[i]||function(){(m[i].a=m[i].a||[]).push(arguments)};
+            m[i].l=1*new Date();
+            for (var j = 0; j < document.scripts.length; j++) {if (document.scripts[j].src === r) { return; }}
+            k=e.createElement(t),a=e.getElementsByTagName(t)[0],k.async=1,k.src=r,a.parentNode.insertBefore(k,a)
+        })(window, document,'script','https://mc.yandex.ru/metrika/tag.js', 'ym');
+
+        ym(98270380, 'init', {webvisor:true, clickmap:true, accurateTrackBounce:true, trackLinks:true});
+    </script>
+    <noscript><div><img src="https://mc.yandex.ru/watch/98270380" style="position:absolute; left:-9999px;" alt="" /></div></noscript>
+    <!-- /Yandex.Metrika counter -->
+
 </head>
 <body class="bg-white text-gray-800 font-sans">
 <header class="border-b bg-white">
@@ -382,5 +396,14 @@ bookingModal.addEventListener('click', e => {
 
 </script>
 <script>lucide.createIcons();</script>
+<script>
+  document.querySelectorAll('.booking-button').forEach(btn => {
+    btn.addEventListener('click', () => ym(98270380, 'reachGoal', 'booking'));
+  });
+  document.querySelectorAll('a[href^="tel:"], a[href^="mailto:"], a[href*="wa.me"], a[href*="t.me"]').forEach(link => {
+    link.addEventListener('click', () => ym(98270380, 'reachGoal', 'contact'));
+  });
+</script>
+
 </body>
 </html>

--- a/gender-party-irkutsk/index.html
+++ b/gender-party-irkutsk/index.html
@@ -47,6 +47,20 @@
   "sameAs":["https://vk.com/...","https://instagram.com/..."]
 }
 </script>
+    <!-- Yandex.Metrika counter -->
+    <script type="text/javascript">
+        (function(m,e,t,r,i,k,a){
+            m[i]=m[i]||function(){(m[i].a=m[i].a||[]).push(arguments)};
+            m[i].l=1*new Date();
+            for (var j = 0; j < document.scripts.length; j++) {if (document.scripts[j].src === r) { return; }}
+            k=e.createElement(t),a=e.getElementsByTagName(t)[0],k.async=1,k.src=r,a.parentNode.insertBefore(k,a)
+        })(window, document,'script','https://mc.yandex.ru/metrika/tag.js', 'ym');
+
+        ym(98270380, 'init', {webvisor:true, clickmap:true, accurateTrackBounce:true, trackLinks:true});
+    </script>
+    <noscript><div><img src="https://mc.yandex.ru/watch/98270380" style="position:absolute; left:-9999px;" alt="" /></div></noscript>
+    <!-- /Yandex.Metrika counter -->
+
 </head>
 <body class="bg-white text-gray-800 font-sans">
 <header class="border-b bg-white">
@@ -382,5 +396,14 @@ bookingModal.addEventListener('click', e => {
 
 </script>
 <script>lucide.createIcons();</script>
+<script>
+  document.querySelectorAll('.booking-button').forEach(btn => {
+    btn.addEventListener('click', () => ym(98270380, 'reachGoal', 'booking'));
+  });
+  document.querySelectorAll('a[href^="tel:"], a[href^="mailto:"], a[href*="wa.me"], a[href*="t.me"]').forEach(link => {
+    link.addEventListener('click', () => ym(98270380, 'reachGoal', 'contact'));
+  });
+</script>
+
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -18,23 +18,7 @@
   <link rel="icon" href="img/suncity-sun-camera.ico" type="image/x-icon" />
   <script src="https://cdn.tailwindcss.com"></script>
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/swiper@9/swiper-bundle.min.css" />
-  <script src="https://unpkg.com/lucide@latest"></script>
-    <!-- Yandex.Metrika counter -->
-  <script type="text/javascript">
-    (function(m,e,t,r,i,k,a){m[i]=m[i]||function(){(m[i].a=m[i].a||[]).push(arguments)};
-    m[i].l=1*new Date();
-    k=e.createElement(t),a=e.getElementsByTagName(t)[0],k.async=1,k.src=r,a.parentNode.insertBefore(k,a)})
-    (window, document, "script", "https://mc.yandex.ru/metrika/tag.js", "ym");
-
-    ym(98270380, "init", {
-          clickmap:true,
-          trackLinks:true,
-          accurateTrackBounce:true
-    });
-  </script>
-  <noscript><div><img src="https://mc.yandex.ru/watch/98270380" style="position:absolute; left:-9999px;" alt="" /></div></noscript>
-  <!-- /Yandex.Metrika counter -->
-<script type="application/ld+json">
+  <script src="https://unpkg.com/lucide@latest"></script><script type="application/ld+json">
 {
   "@context":"https://schema.org",
   "@type":["LocalBusiness","Photographystudio","DanceStudio"],
@@ -85,6 +69,20 @@
 </script>
 
 
+
+    <!-- Yandex.Metrika counter -->
+    <script type="text/javascript">
+        (function(m,e,t,r,i,k,a){
+            m[i]=m[i]||function(){(m[i].a=m[i].a||[]).push(arguments)};
+            m[i].l=1*new Date();
+            for (var j = 0; j < document.scripts.length; j++) {if (document.scripts[j].src === r) { return; }}
+            k=e.createElement(t),a=e.getElementsByTagName(t)[0],k.async=1,k.src=r,a.parentNode.insertBefore(k,a)
+        })(window, document,'script','https://mc.yandex.ru/metrika/tag.js', 'ym');
+
+        ym(98270380, 'init', {webvisor:true, clickmap:true, accurateTrackBounce:true, trackLinks:true});
+    </script>
+    <noscript><div><img src="https://mc.yandex.ru/watch/98270380" style="position:absolute; left:-9999px;" alt="" /></div></noscript>
+    <!-- /Yandex.Metrika counter -->
 
 </head>
 <body class="bg-white text-gray-800 font-sans">
@@ -601,5 +599,14 @@
   </footer>
 
     <!-- SEO & analytics are connected in the head above -->
-  </body>
+  <script>
+  document.querySelectorAll('.booking-button').forEach(btn => {
+    btn.addEventListener('click', () => ym(98270380, 'reachGoal', 'booking'));
+  });
+  document.querySelectorAll('a[href^="tel:"], a[href^="mailto:"], a[href*="wa.me"], a[href*="t.me"]').forEach(link => {
+    link.addEventListener('click', () => ym(98270380, 'reachGoal', 'contact'));
+  });
+</script>
+
+</body>
 </html>

--- a/kontakty/index.html
+++ b/kontakty/index.html
@@ -17,6 +17,20 @@
 <link rel="icon" href="../img/suncity-sun-camera.ico" type="image/x-icon" />
 <script src="https://cdn.tailwindcss.com"></script>
 <script src="https://unpkg.com/lucide@latest"></script>
+    <!-- Yandex.Metrika counter -->
+    <script type="text/javascript">
+        (function(m,e,t,r,i,k,a){
+            m[i]=m[i]||function(){(m[i].a=m[i].a||[]).push(arguments)};
+            m[i].l=1*new Date();
+            for (var j = 0; j < document.scripts.length; j++) {if (document.scripts[j].src === r) { return; }}
+            k=e.createElement(t),a=e.getElementsByTagName(t)[0],k.async=1,k.src=r,a.parentNode.insertBefore(k,a)
+        })(window, document,'script','https://mc.yandex.ru/metrika/tag.js', 'ym');
+
+        ym(98270380, 'init', {webvisor:true, clickmap:true, accurateTrackBounce:true, trackLinks:true});
+    </script>
+    <noscript><div><img src="https://mc.yandex.ru/watch/98270380" style="position:absolute; left:-9999px;" alt="" /></div></noscript>
+    <!-- /Yandex.Metrika counter -->
+
 </head>
 <body class="bg-white text-gray-800 font-sans">
 <header class="border-b bg-white">
@@ -137,5 +151,14 @@ bookingModal.addEventListener('click', e => {
 
 </script>
 <script>lucide.createIcons();</script>
+<script>
+  document.querySelectorAll('.booking-button').forEach(btn => {
+    btn.addEventListener('click', () => ym(98270380, 'reachGoal', 'booking'));
+  });
+  document.querySelectorAll('a[href^="tel:"], a[href^="mailto:"], a[href*="wa.me"], a[href*="t.me"]').forEach(link => {
+    link.addEventListener('click', () => ym(98270380, 'reachGoal', 'contact'));
+  });
+</script>
+
 </body>
 </html>

--- a/meropriyatiya-irkutsk/index.html
+++ b/meropriyatiya-irkutsk/index.html
@@ -47,6 +47,20 @@
   "sameAs":["https://vk.com/...","https://instagram.com/..."]
 }
 </script>
+    <!-- Yandex.Metrika counter -->
+    <script type="text/javascript">
+        (function(m,e,t,r,i,k,a){
+            m[i]=m[i]||function(){(m[i].a=m[i].a||[]).push(arguments)};
+            m[i].l=1*new Date();
+            for (var j = 0; j < document.scripts.length; j++) {if (document.scripts[j].src === r) { return; }}
+            k=e.createElement(t),a=e.getElementsByTagName(t)[0],k.async=1,k.src=r,a.parentNode.insertBefore(k,a)
+        })(window, document,'script','https://mc.yandex.ru/metrika/tag.js', 'ym');
+
+        ym(98270380, 'init', {webvisor:true, clickmap:true, accurateTrackBounce:true, trackLinks:true});
+    </script>
+    <noscript><div><img src="https://mc.yandex.ru/watch/98270380" style="position:absolute; left:-9999px;" alt="" /></div></noscript>
+    <!-- /Yandex.Metrika counter -->
+
 </head>
 <body class="bg-white text-gray-800 font-sans">
 <header class="border-b bg-white">
@@ -381,5 +395,14 @@ bookingModal.addEventListener('click', e => {
 
 </script>
 <script>lucide.createIcons();</script>
+<script>
+  document.querySelectorAll('.booking-button').forEach(btn => {
+    btn.addEventListener('click', () => ym(98270380, 'reachGoal', 'booking'));
+  });
+  document.querySelectorAll('a[href^="tel:"], a[href^="mailto:"], a[href*="wa.me"], a[href*="t.me"]').forEach(link => {
+    link.addEventListener('click', () => ym(98270380, 'reachGoal', 'contact'));
+  });
+</script>
+
 </body>
 </html>

--- a/pravila/index.html
+++ b/pravila/index.html
@@ -47,6 +47,20 @@
 }
 </script>
 
+    <!-- Yandex.Metrika counter -->
+    <script type="text/javascript">
+        (function(m,e,t,r,i,k,a){
+            m[i]=m[i]||function(){(m[i].a=m[i].a||[]).push(arguments)};
+            m[i].l=1*new Date();
+            for (var j = 0; j < document.scripts.length; j++) {if (document.scripts[j].src === r) { return; }}
+            k=e.createElement(t),a=e.getElementsByTagName(t)[0],k.async=1,k.src=r,a.parentNode.insertBefore(k,a)
+        })(window, document,'script','https://mc.yandex.ru/metrika/tag.js', 'ym');
+
+        ym(98270380, 'init', {webvisor:true, clickmap:true, accurateTrackBounce:true, trackLinks:true});
+    </script>
+    <noscript><div><img src="https://mc.yandex.ru/watch/98270380" style="position:absolute; left:-9999px;" alt="" /></div></noscript>
+    <!-- /Yandex.Metrika counter -->
+
 </head>
 <body class="bg-white text-gray-800 font-sans">
 <header class="border-b bg-white">
@@ -162,5 +176,14 @@ bookingModal.addEventListener('click', e => {
 
 </script>
 <script>lucide.createIcons();</script>
+<script>
+  document.querySelectorAll('.booking-button').forEach(btn => {
+    btn.addEventListener('click', () => ym(98270380, 'reachGoal', 'booking'));
+  });
+  document.querySelectorAll('a[href^="tel:"], a[href^="mailto:"], a[href*="wa.me"], a[href*="t.me"]').forEach(link => {
+    link.addEventListener('click', () => ym(98270380, 'reachGoal', 'contact'));
+  });
+</script>
+
 </body>
 </html>

--- a/tancy-zal-irkutsk/index.html
+++ b/tancy-zal-irkutsk/index.html
@@ -47,6 +47,20 @@
   "sameAs":["https://vk.com/...","https://instagram.com/..."]
 }
 </script>
+    <!-- Yandex.Metrika counter -->
+    <script type="text/javascript">
+        (function(m,e,t,r,i,k,a){
+            m[i]=m[i]||function(){(m[i].a=m[i].a||[]).push(arguments)};
+            m[i].l=1*new Date();
+            for (var j = 0; j < document.scripts.length; j++) {if (document.scripts[j].src === r) { return; }}
+            k=e.createElement(t),a=e.getElementsByTagName(t)[0],k.async=1,k.src=r,a.parentNode.insertBefore(k,a)
+        })(window, document,'script','https://mc.yandex.ru/metrika/tag.js', 'ym');
+
+        ym(98270380, 'init', {webvisor:true, clickmap:true, accurateTrackBounce:true, trackLinks:true});
+    </script>
+    <noscript><div><img src="https://mc.yandex.ru/watch/98270380" style="position:absolute; left:-9999px;" alt="" /></div></noscript>
+    <!-- /Yandex.Metrika counter -->
+
 </head>
 <body class="bg-white text-gray-800 font-sans">
 <header class="border-b bg-white">
@@ -382,5 +396,14 @@ bookingModal.addEventListener('click', e => {
 
 </script>
 <script>lucide.createIcons();</script>
+<script>
+  document.querySelectorAll('.booking-button').forEach(btn => {
+    btn.addEventListener('click', () => ym(98270380, 'reachGoal', 'booking'));
+  });
+  document.querySelectorAll('a[href^="tel:"], a[href^="mailto:"], a[href*="wa.me"], a[href*="t.me"]').forEach(link => {
+    link.addEventListener('click', () => ym(98270380, 'reachGoal', 'contact'));
+  });
+</script>
+
 </body>
 </html>

--- a/yoga-zal-irkutsk/index.html
+++ b/yoga-zal-irkutsk/index.html
@@ -47,6 +47,20 @@
   "sameAs":["https://vk.com/...","https://instagram.com/..."]
 }
 </script>
+    <!-- Yandex.Metrika counter -->
+    <script type="text/javascript">
+        (function(m,e,t,r,i,k,a){
+            m[i]=m[i]||function(){(m[i].a=m[i].a||[]).push(arguments)};
+            m[i].l=1*new Date();
+            for (var j = 0; j < document.scripts.length; j++) {if (document.scripts[j].src === r) { return; }}
+            k=e.createElement(t),a=e.getElementsByTagName(t)[0],k.async=1,k.src=r,a.parentNode.insertBefore(k,a)
+        })(window, document,'script','https://mc.yandex.ru/metrika/tag.js', 'ym');
+
+        ym(98270380, 'init', {webvisor:true, clickmap:true, accurateTrackBounce:true, trackLinks:true});
+    </script>
+    <noscript><div><img src="https://mc.yandex.ru/watch/98270380" style="position:absolute; left:-9999px;" alt="" /></div></noscript>
+    <!-- /Yandex.Metrika counter -->
+
 </head>
 <body class="bg-white text-gray-800 font-sans">
 <header class="border-b bg-white">
@@ -367,5 +381,14 @@ bookingModal.addEventListener('click', e => {
 
 </script>
 <script>lucide.createIcons();</script>
+<script>
+  document.querySelectorAll('.booking-button').forEach(btn => {
+    btn.addEventListener('click', () => ym(98270380, 'reachGoal', 'booking'));
+  });
+  document.querySelectorAll('a[href^="tel:"], a[href^="mailto:"], a[href*="wa.me"], a[href*="t.me"]').forEach(link => {
+    link.addEventListener('click', () => ym(98270380, 'reachGoal', 'contact'));
+  });
+</script>
+
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Update Yandex.Metrika snippet across site with Webvisor enabled
- Track booking and contact interactions as Yandex goals

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68abcccf0858832c9acaac9c7ec8bc9c